### PR TITLE
chore(build): add npm pkg metadata; remove types build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,22 @@
 {
   "name": "diff2prompt",
+  "version": "0.0.1",
+  "author": "watanabe-1",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/watanabe-1/diff2prompt"
+  },
+  "homepage": "https://github.com/watanabe-1/diff2prompt#readme",
+  "bugs": {
+    "url": "https://github.com/watanabe-1/diff2prompt/issues"
+  },
+  "keywords": [
+    "typescript",
+    "cli"
+  ],
   "module": "dist/index.js",
   "type": "module",
-  "private": true,
   "files": [
     "dist"
   ],
@@ -10,8 +24,7 @@
     "diff2prompt": "dist/index.js"
   },
   "scripts": {
-    "build": "bun run clean && bun build.ts && bun run build:types",
-    "build:types": "tsc -p tsconfig.build-types.json",
+    "build": "bun run clean && bun build.ts",
     "clean": "bun -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage.enabled true",

--- a/tsconfig.build-types.json
+++ b/tsconfig.build-types.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "declaration": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "src/**/*.test.ts", "src/cli/**"]
-}


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added npm package metadata (version, author, license, repository, homepage, bugs, keywords)
* Removed `tsconfig.build-types.json` and related build step for type declarations

## 🧐 Motivation and Background

* To prepare the package for npm publishing with proper metadata
* To simplify build process by removing the separate types build config

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Build configuration updated

## 💡 Notes / Screenshots

* Now the package.json is npm-ready and no longer marked as private.

## 🔄 Testing

* [ ] `bun run lint` passed
* [x] `bun run test` passed
* [ ] Manual verification completed
