### PR TITLE
feat: add config loader and default output path resolution

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Hoisted mocks (user preference)
+const mockFiles = vi.hoisted(() => {
+  // virtual filesystem map
+  return new Map<string, string>();
+});
+
+const mockRepoRoot = vi.hoisted(() => ({ value: "C:/repo" }));
+
+const norm = (p: string) => p.replace(/\\/g, "/");
+
+vi.mock("fs/promises", () => {
+  return {
+    readFile: vi.fn((p: string) => {
+      const key = norm(String(p));
+      const v = mockFiles.get(key);
+      if (v === null) return Promise.reject(new Error("ENOENT"));
+
+      return Promise.resolve(v);
+    }),
+    writeFile: vi.fn(),
+    stat: vi.fn(),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const execState = ((globalThis as any).__execState__ ??= {
+  stdout: "C:/repo\n",
+  throws: false,
+});
+
+vi.mock("child_process", async () => {
+  const { promisify } = await import("util");
+
+  // 既存 execState を拡張（shape を追加）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const execState = ((globalThis as any).__execState__ ??= {
+    stdout: "C:/repo\n",
+    throws: false,
+    shape: "string" as "string" | "array" | "object",
+  });
+
+  function rawExec(
+    cmd: string,
+    cb?: (err: unknown, stdout: string, stderr: string) => void
+  ) {
+    if (execState.throws) {
+      const err = new Error("fail");
+      cb?.(err, "", "");
+      throw err;
+    }
+    cb?.(null, execState.stdout, "");
+
+    // 返り値は互換用のダミー
+    return { stdout: execState.stdout, stderr: "" } as unknown;
+  }
+
+  // ここがポイント：promisify.custom で戻り値“の形”を切替
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (rawExec as any)[promisify.custom] = (_: string) => {
+    if (execState.throws) {
+      return Promise.reject(new Error("fail"));
+    }
+    switch (execState.shape) {
+      case "array":
+        return Promise.resolve([execState.stdout, ""]);
+      case "object":
+        return Promise.resolve({ stdout: execState.stdout, stderr: "" });
+      default: // "string"
+        return Promise.resolve(execState.stdout);
+    }
+  };
+
+  return { exec: rawExec };
+});
+
+vi.mock("path", async (orig) => {
+  // Use real path module; Windows-like paths are fine for tests
+  return await orig();
+});
+
+import {
+  loadUserConfig,
+  normalizeUserConfig,
+  resolveDefaultOutputPath,
+  mergeOptions,
+  isAbsolutePath,
+  getRepoRootSafe,
+} from "./config";
+import type { Options } from "./generate-prompt-from-git-diff";
+
+const defaults: Options = {
+  maxConsoleLines: 10,
+  outputPath: "",
+  includeUntracked: true,
+  maxNewFileSizeBytes: 1_000_000,
+  maxBuffer: 50 * 1024 * 1024,
+};
+
+function putFile(path: string, json: unknown) {
+  mockFiles.set(norm(path), JSON.stringify(json));
+}
+
+function rec(v: unknown): Record<string, unknown> {
+  return v as Record<string, unknown>;
+}
+
+describe("config loader & merge", () => {
+  beforeEach(() => {
+    mockFiles.clear();
+    delete process.env.DIFF2PROMPT_CONFIG;
+    mockRepoRoot.value = "C:/repo";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes outputPath relative to baseDir", () => {
+    const cfg = normalizeUserConfig({ outputPath: "out/p.txt" }, "C:/repo");
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe(
+      "C:/repo/out/p.txt".replace(/\\/g, "/")
+    );
+  });
+
+  it("falls back to outputFile when outputPath is absent", () => {
+    const cfg = normalizeUserConfig({ outputFile: "p.md" }, "C:/repo");
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe(
+      "C:/repo/p.md".replace(/\\/g, "/")
+    );
+  });
+
+  it("accepts absolute paths as-is", () => {
+    const abs = "C:/tmp/p.txt";
+    const cfg = normalizeUserConfig({ outputPath: abs }, "C:/repo");
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe(abs.replace(/\\/g, "/"));
+    expect(isAbsolutePath(abs)).toBe(true);
+  });
+
+  it("loadUserConfig: env path has highest priority among files", async () => {
+    // Lower-priority files present
+    putFile("C:/repo/diff2prompt.config.json", { outputFile: "low.txt" });
+    putFile("C:/repo/package.json", { diff2prompt: { outputFile: "pkg.txt" } });
+
+    // Env points to a custom config
+    process.env.DIFF2PROMPT_CONFIG = "C:/custom/cfg.json";
+    putFile("C:/custom/cfg.json", { outputPath: "env.json.txt" });
+
+    const cfg = await loadUserConfig("C:/repo");
+    expect(cfg.outputPath?.endsWith("env.json.txt")).toBe(true);
+  });
+
+  it("loadUserConfig: falls through to diff2prompt.config.json, then .diff2promptrc, then package.json", async () => {
+    // Only package.json exists at first
+    putFile("C:/repo/package.json", { diff2prompt: { outputFile: "pkg.txt" } });
+    let cfg = await loadUserConfig("C:/repo");
+    expect(cfg.outputPath?.endsWith("pkg.txt")).toBe(true);
+
+    // Add .diff2promptrc
+    putFile("C:/repo/.diff2promptrc", { outputFile: "rc.txt" });
+    cfg = await loadUserConfig("C:/repo");
+    expect(cfg.outputPath?.endsWith("rc.txt")).toBe(true);
+
+    // Add diff2prompt.config.json (highest among default files)
+    putFile("C:/repo/diff2prompt.config.json", { outputFile: "conf.txt" });
+    cfg = await loadUserConfig("C:/repo");
+    expect(cfg.outputPath?.endsWith("conf.txt")).toBe(true);
+  });
+
+  it("mergeOptions: CLI overrides file config", () => {
+    const fileCfg = normalizeUserConfig({ outputFile: "file.txt" }, "C:/repo");
+    const cli: Partial<Options> = { outputPath: "C:/cli/over.txt" };
+    const merged = mergeOptions(
+      defaults,
+      fileCfg,
+      cli,
+      "C:/repo",
+      "C:/fallback"
+    );
+    expect(merged.outputPath.replace(/\\/g, "/")).toBe(
+      "C:/cli/over.txt".replace(/\\/g, "/")
+    );
+  });
+
+  it("resolveDefaultOutputPath: uses repoRoot when available, else fallback", () => {
+    const p1 = resolveDefaultOutputPath("C:/repo", "C:/cwd");
+    expect(p1.replace(/\\/g, "/")).toBe(
+      "C:/repo/generated-prompt.txt".replace(/\\/g, "/")
+    );
+    const p2 = resolveDefaultOutputPath(null, "C:/cwd");
+    expect(p2.replace(/\\/g, "/")).toBe(
+      "C:/cwd/generated-prompt.txt".replace(/\\/g, "/")
+    );
+  });
+});
+
+describe("getRepoRootSafe – full branch coverage", () => {
+  beforeEach(() => {
+    execState.stdout = "C:/repo\n";
+    execState.throws = false;
+    execState.shape = "string";
+  });
+
+  it("handles string result", async () => {
+    execState.shape = "string";
+    execState.stdout = "C:/repo\n";
+    const root = await getRepoRootSafe();
+    expect(root).toBe("C:/repo");
+  });
+
+  it("handles array result [stdout, stderr]", async () => {
+    execState.shape = "array";
+    execState.stdout = "C:/repo-array\n";
+    const root = await getRepoRootSafe();
+    expect(root).toBe("C:/repo-array");
+  });
+
+  it("handles array non string result [stdout, stderr]", async () => {
+    execState.shape = "array";
+    execState.stdout = 1;
+    const root = await getRepoRootSafe();
+    expect(root).toBeNull();
+  });
+
+  it("handles object result { stdout, stderr }", async () => {
+    execState.shape = "object";
+    execState.stdout = "C:/repo-obj\n";
+    const root = await getRepoRootSafe();
+    expect(root).toBe("C:/repo-obj");
+  });
+
+  it("handles object non string result { stdout, stderr }", async () => {
+    execState.shape = "object";
+    execState.stdout = 1;
+    const root = await getRepoRootSafe();
+    expect(root).toBeNull();
+  });
+
+  it("returns null on empty stdout", async () => {
+    execState.shape = "string"; // 形は何でも良い
+    execState.stdout = "\n";
+    const root = await getRepoRootSafe();
+    expect(root).toBeNull();
+  });
+
+  it("returns null when exec throws", async () => {
+    execState.throws = true;
+    const root = await getRepoRootSafe();
+    expect(root).toBeNull();
+  });
+});
+
+describe("normalizeUserConfig", () => {
+  it("returns {} when not record", () => {
+    expect(normalizeUserConfig(null, "C:/repo")).toEqual({});
+    expect(normalizeUserConfig(123, "C:/repo")).toEqual({});
+  });
+
+  it("resolves relative outputPath", () => {
+    const cfg = normalizeUserConfig(rec({ outputPath: "out.txt" }), "C:/repo");
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe("C:/repo/out.txt");
+  });
+
+  it("resolves absolute outputPath", () => {
+    const cfg = normalizeUserConfig(
+      rec({ outputPath: "C:/abs/out.txt" }),
+      "C:/repo"
+    );
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe("C:/abs/out.txt");
+  });
+
+  it("resolves relative outputFile", () => {
+    const cfg = normalizeUserConfig(rec({ outputFile: "file.md" }), "C:/repo");
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe("C:/repo/file.md");
+  });
+
+  it("resolves absolute outputFile", () => {
+    const cfg = normalizeUserConfig(
+      rec({ outputFile: "C:/abs/file.md" }),
+      "C:/repo"
+    );
+    expect(cfg.outputPath?.replace(/\\/g, "/")).toBe("C:/abs/file.md");
+  });
+
+  it("handles numbers, booleans, buffer size", () => {
+    const cfg = normalizeUserConfig(
+      rec({
+        maxConsoleLines: 20,
+        includeUntracked: false,
+        maxNewFileSizeBytes: 123,
+        maxBuffer: 456,
+      }),
+      "C:/repo"
+    );
+    expect(cfg.maxConsoleLines).toBe(20);
+    expect(cfg.includeUntracked).toBe(false);
+    expect(cfg.maxNewFileSizeBytes).toBe(123);
+    expect(cfg.maxBuffer).toBe(456);
+  });
+
+  it("ignores wrong types", () => {
+    const cfg = normalizeUserConfig(
+      rec({
+        maxConsoleLines: "oops",
+        includeUntracked: "no",
+        maxNewFileSizeBytes: "big",
+        maxBuffer: "xx",
+      }),
+      "C:/repo"
+    );
+    expect(cfg).toEqual({});
+  });
+});
+
+describe("isAbsolutePath", () => {
+  it("detects absolute Windows path", () => {
+    expect(isAbsolutePath("C:/repo")).toBe(true);
+    expect(isAbsolutePath("C:\\repo")).toBe(true);
+  });
+  it("detects UNC path", () => {
+    expect(isAbsolutePath("\\\\server\\share")).toBe(true);
+  });
+  it("detects posix absolute path", () => {
+    expect(isAbsolutePath("/usr/bin")).toBe(true);
+  });
+  it("detects relative path", () => {
+    expect(isAbsolutePath("out/file.txt")).toBe(false);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,222 @@
+import { exec as cpExec } from "child_process";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { promisify } from "util";
+import type { Options } from "./generate-prompt-from-git-diff";
+
+const exec = promisify(cpExec);
+
+export type UserConfig = Partial<{
+  outputPath: string;
+  outputFile: string;
+  maxConsoleLines: number;
+  includeUntracked: boolean;
+  maxNewFileSizeBytes: number;
+  maxBuffer: number;
+}>;
+
+// 値の型 V (例: string/number/boolean など) に"代入可能"なプロパティのキーを抽出
+// - IncludeOptional が true のときは undefined を無視して判定（Partial対策）
+type KeysByType<T, V, IncludeOptional extends boolean = false> = {
+  [K in keyof T]-?: IncludeOptional extends true
+    ? NonNullable<T[K]> extends V
+      ? K
+      : never
+    : T[K] extends V
+      ? K
+      : never;
+}[keyof T];
+
+type StringKeys<T, IncludeOptional extends boolean = true> = KeysByType<
+  T,
+  string,
+  IncludeOptional
+>;
+type NumberKeys<T, IncludeOptional extends boolean = true> = KeysByType<
+  T,
+  number,
+  IncludeOptional
+>;
+type BooleanKeys<T, IncludeOptional extends boolean = true> = KeysByType<
+  T,
+  boolean,
+  IncludeOptional
+>;
+
+export async function getRepoRootSafe(): Promise<string | null> {
+  try {
+    const res = await exec("git rev-parse --show-toplevel");
+
+    // Handle possible shapes from promisified exec:
+    // - string                => stdout
+    // - [stdout, stderr]      => array (generic promisify with multiple args)
+    // - { stdout, stderr }    => real exec with custom promisify
+    let stdout: string | undefined;
+
+    if (typeof res === "string") {
+      stdout = res;
+    } else if (Array.isArray(res)) {
+      stdout = typeof res[0] === "string" ? res[0] : undefined;
+    } else if (res && typeof res === "object" && "stdout" in res) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const r: any = res;
+      stdout = typeof r.stdout === "string" ? r.stdout : undefined;
+    }
+
+    const root = (stdout ?? "").trim();
+
+    return root ? root : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readJsonIfExists(path: string): Promise<unknown | null> {
+  try {
+    const buf = await readFile(path, "utf8");
+
+    return JSON.parse(buf) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function pickString(
+  obj: Record<string, unknown>,
+  key: StringKeys<UserConfig>
+): string | undefined {
+  const v = obj[key];
+
+  return typeof v === "string" ? v : undefined;
+}
+
+function pickNumber(
+  obj: Record<string, unknown>,
+  key: NumberKeys<UserConfig>
+): number | undefined {
+  const v = obj[key];
+
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function pickBoolean(
+  obj: Record<string, unknown>,
+  key: BooleanKeys<UserConfig>
+): boolean | undefined {
+  const v = obj[key];
+
+  return typeof v === "boolean" ? v : undefined;
+}
+
+export function isAbsolutePath(p: string): boolean {
+  // Windows drive or UNC or posix absolute
+  return /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith("\\\\") || p.startsWith("/");
+}
+
+/** 設定ファイルの raw を Options 部分集合へ正規化（パス解決込み） */
+export function normalizeUserConfig(
+  cfgRaw: unknown,
+  baseDir: string
+): Partial<Options> {
+  if (!isRecord(cfgRaw)) return {};
+
+  const out: Partial<Options> = {};
+  const outputPath = pickString(cfgRaw, "outputPath");
+  const outputFile = pickString(cfgRaw, "outputFile");
+
+  let resolvedOutputPath: string | undefined;
+
+  if (outputPath && outputPath.trim()) {
+    resolvedOutputPath = isAbsolutePath(outputPath)
+      ? outputPath
+      : join(baseDir, outputPath);
+  } else if (outputFile && outputFile.trim()) {
+    resolvedOutputPath = isAbsolutePath(outputFile)
+      ? outputFile
+      : join(baseDir, outputFile);
+  }
+
+  if (resolvedOutputPath) out.outputPath = resolvedOutputPath;
+
+  const maxConsoleLines = pickNumber(cfgRaw, "maxConsoleLines");
+  const includeUntracked = pickBoolean(cfgRaw, "includeUntracked");
+  const maxNewFileSizeBytes = pickNumber(cfgRaw, "maxNewFileSizeBytes");
+  const maxBuffer = pickNumber(cfgRaw, "maxBuffer");
+
+  if (typeof maxConsoleLines === "number")
+    out.maxConsoleLines = maxConsoleLines;
+  if (typeof includeUntracked === "boolean")
+    out.includeUntracked = includeUntracked;
+  if (typeof maxNewFileSizeBytes === "number")
+    out.maxNewFileSizeBytes = maxNewFileSizeBytes;
+  if (typeof maxBuffer === "number") out.maxBuffer = maxBuffer;
+
+  return out;
+}
+
+/** 設定ファイルの探索 & 読み込み（優先順位順） */
+export async function loadUserConfig(
+  baseDir: string
+): Promise<Partial<Options>> {
+  // 1) 明示パス（環境変数）
+  if (process.env.DIFF2PROMPT_CONFIG) {
+    const cfg = await readJsonIfExists(process.env.DIFF2PROMPT_CONFIG);
+    if (cfg) return normalizeUserConfig(cfg, baseDir);
+  }
+
+  // 2) 既定の設定ファイル
+  const candidates = [
+    join(baseDir, "diff2prompt.config.json"),
+    join(baseDir, ".diff2promptrc"),
+  ];
+  for (const p of candidates) {
+    const cfg = await readJsonIfExists(p);
+    if (cfg) return normalizeUserConfig(cfg, baseDir);
+  }
+
+  // 3) package.json の diff2prompt フィールド
+  const pkgRaw = await readJsonIfExists(join(baseDir, "package.json"));
+  if (isRecord(pkgRaw)) {
+    const d2p = pkgRaw["diff2prompt"]; // unknown
+    if (d2p !== undefined) {
+      return normalizeUserConfig(d2p, baseDir); // normalizeUserConfig accepts unknown
+    }
+  }
+
+  return {};
+}
+
+/** 既定の出力先（repoRoot 優先、なければ cwd） */
+export function resolveDefaultOutputPath(
+  repoRoot: string | null,
+  fallbackDir: string,
+  filename = "generated-prompt.txt"
+): string {
+  const base = repoRoot ?? fallbackDir;
+
+  return join(base, filename);
+}
+
+/** 既定値 → 設定ファイル → CLI の順でマージした Options を返す */
+export function mergeOptions(
+  defaults: Options,
+  fileCfg: Partial<Options>,
+  cli: Partial<Options>,
+  repoRoot: string | null,
+  fallbackDir: string
+): Options {
+  const merged: Options = {
+    ...defaults,
+    ...fileCfg,
+    ...cli,
+  };
+  if (!merged.outputPath || !merged.outputPath.trim()) {
+    merged.outputPath = resolveDefaultOutputPath(repoRoot, fallbackDir);
+  }
+
+  return merged;
+}


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Introduce `src/config.ts` to load and normalize user config from multiple sources (env → config files → package.json).
* Update `main()` flow to merge **defaults → file config → CLI** and resolve a default `outputPath` based on repo root or cwd.
* Harden git-root detection via `getRepoRootSafe()` to handle various `exec` promisify shapes and failures gracefully.
* Add comprehensive tests: config loader/merging, default path resolution, and flow-level checks for both branches of the `repoRoot || __DIRNAME_SAFE` decision.

## 🧐 Motivation and Background

* Users need a predictable way to configure output and limits without rewriting CLI flags each run.
* The default output path previously depended on `__DIRNAME_SAFE`; now it prefers the repository root when available, improving DX and keeping generated artifacts inside the repo by default.
* `exec` return shapes vary by environment/mocking; we now robustly support string/tuple/object to avoid brittle failures.

## ✅ Changes

* [x] **Feature added**: Config loader (`loadUserConfig`, `normalizeUserConfig`, `mergeOptions`, `resolveDefaultOutputPath`).
* [x] **Refactored**: `main()` now assembles options from defaults, file config, and CLI, and finalizes `outputPath` if empty.
* [x] **Test updates**: New `src/config.test.ts`; expanded unit/flow tests to cover repo-root vs fallback branching and parse/merge behavior.
* [ ] Documentation updated (follow‑up: README usage section for config precedence & examples).

## 🔧 Technical Details

* **Config precedence**

  1. `DIFF2PROMPT_CONFIG` (JSON) →
  2. `diff2prompt.config.json` → `.diff2promptrc` →
  3. `package.json` `diff2prompt` field
* **Path handling**

  * Relative `outputPath`/`outputFile` are resolved against repo root.
  * Absolute paths are respected as-is.
  * Default: `resolveDefaultOutputPath(repoRoot, cwd, "generated-prompt.txt")`.
* **Exec robustness**

  * Accepts `string`, `[stdout, stderr]`, or `{ stdout, stderr }` from promisified `exec`.
  * Trims/validates stdout; returns `null` on empty/throw.

## 💡 Notes / Screenshots

* Follow‑up tasks:

  * Add README section with config file examples and CLI overrides.
  * Consider a `--config` CLI flag to mirror `DIFF2PROMPT_CONFIG`.
  * Optionally log resolved config when `--verbose` is set (future work).

## 🔄 Testing

* [x] `bun run test` passed locally
* [x] Flow tests:

  * Default output when **repoRoot provided** → writes under `/repo/...generated-prompt.txt`.
  * Default output when **repoRoot is empty** → falls back to `__DIRNAME_SAFE`/cwd.
* [x] Unit tests:

  * Config precedence and normalization (relative vs absolute).
  * `mergeOptions` order and CLI override of file config.
  * `getRepoRootSafe` covers string/array/object/throw/empty cases.
* [ ] `bun run lint` (no new lint errors expected)

---

**Title**: \`feat(config): add config loader and default output path resoluti
