### PR TITLE
refactor(constants): extract defaults and presets; adopt DEFAULT_MAX_BUFFER

### DIFF
--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import {
+  TEMPLATE_PRESETS,
+  MAX_CONSOLE_LINES_DEFAULT,
+  MAX_NEWFILE_SIZE_BYTES,
+  DEFAULT_MAX_BUFFER,
+} from "../src/constants";
+
+describe("constants", () => {
+  it("exports sane defaults and presets", () => {
+    expect(MAX_CONSOLE_LINES_DEFAULT).toBe(10);
+    expect(MAX_NEWFILE_SIZE_BYTES).toBe(1_000_000);
+    expect(DEFAULT_MAX_BUFFER).toBe(50 * 1024 * 1024);
+    expect(TEMPLATE_PRESETS.default).toContain("Commit message:");
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,68 @@
+/** Console preview default lines */
+export const MAX_CONSOLE_LINES_DEFAULT = 10;
+
+/** 1MB: skip huge new files to avoid giant prompts */
+export const MAX_NEWFILE_SIZE_BYTES = 1_000_000;
+
+/** Default maxBuffer for child_process.exec (50MB) */
+export const DEFAULT_MAX_BUFFER = 50 * 1024 * 1024;
+
+/** Built-in prompt template presets */
+export const TEMPLATE_PRESETS: Record<string, string> = Object.freeze({
+  default: `
+I made changes to the following code. Here is the diff of the modifications:
+
+{{diff}}
+
+Please generate **all** of the following based on the diff:
+
+1) **Commit message** (single line), using one of:
+   - feat: Adding a new feature
+   - fix: Bug fix
+   - refactor: Code refactoring
+   - update: Improvements or updates to existing functionality
+   - docs: Documentation changes
+   - chore: Build-related or tool configuration changes
+   - test: Adding or modifying tests
+
+   Use Conventional Commits format with an **optional scope**:
+   Format: <type>(<optional-scope>): <message>
+   - Keep message concise (≤ 72 chars if possible), sentence case.
+   - Prefer scopes when clear from the diff. Examples:
+     - deps / deps-dev
+     - ci
+     - docs
+     - test
+     - build
+     - perf, security, etc.
+
+2) **PR title**: mirror the commit message exactly.
+
+3) **Branch name**:
+   - Lowercase kebab-case, ASCII [a–z0–9-] only.
+   - Prefix "<type>/" and include "/<scope>" if used.
+   - ≤ 40 chars after the prefix.
+
+**Output format:**
+
+Commit message: <type>(<optional-scope>): <message>
+PR title: <type>(<optional-scope>): <message>
+Branch: <type>[/<scope>]/<short-kebab-slug>
+`.trim(),
+
+  minimal: `
+{{diff}}
+
+Please output:
+- Commit: <type>(<scope?>): <message>
+- PR: same as commit
+- Branch: <type>[/<scope>]/<slug>
+`.trim(),
+
+  ja: `
+次の差分に基づいて、コミットメッセージ（Conventional Commits）、PRタイトル（コミットと同一）、ブランチ名（<type>[/<scope>]/<slug>）を生成してください。
+
+差分:
+{{diff}}
+`.trim(),
+});


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Extracted default values and prompt template presets into **`src/constants.ts`** (`MAX_CONSOLE_LINES_DEFAULT`, `MAX_NEWFILE_SIZE_BYTES`, `DEFAULT_MAX_BUFFER`, `TEMPLATE_PRESETS`).
* Updated **`src/generate-prompt-from-git-diff.ts`** to import from `constants.ts` and removed the in-file `PRESETS` object.
* Standardized buffer default via **`DEFAULT_MAX_BUFFER`** (no functional change—same 50MB).
* Added **`src/constants.test.ts`** to assert exported defaults and that `TEMPLATE_PRESETS.default` contains the expected markers.
* Minor cleanup: rely on centralized constants to reduce duplication and improve maintainability.

## 🧐 Motivation and Background

* Establish a **single source of truth** for shared, stable values.
* Improve **testability** by isolating constants for direct assertions.
* Prevent accidental drift across files and make future tuning (e.g., buffer size) localized.
* Freeze presets to avoid unintended runtime mutations.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* **Backward compatibility:** No breaking changes; `Options` shape and CLI flags are unchanged.
* **Preset keys:** `default`, `minimal`, `ja` remain the same.
* **Mutation safety:** `TEMPLATE_PRESETS` uses `Object.freeze`.

## 🔄 Testing

* [x] `bun run lint` passed
* [x] `bun run test` passed
* [x] New tests: `constants.test.ts` verifies defaults and preset contents

## 📦 Affected Files (high level)

* **Added:** `src/constants.ts`, `src/constants.test.ts`
* **Modified:** `src/generate-prompt-from-git-diff.ts`

## 🧭 Migration / Ops Notes

* None required. Consumers of `Options` or CLI are unaffected. Future contributors should add new built-in templates to `TEMPLATE_PRESETS`.
