### PR TITLE
feat(cli): add --exclude and --exclude-file flags

### DIFF
--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -1,3 +1,4 @@
+// ===== src/generate-prompt-from-git-diff.ts =====
 import { exec as cpExec } from "child_process";
 import { readFile, writeFile, stat } from "fs/promises";
 import { join } from "path";
@@ -15,7 +16,7 @@ import {
   TRUNCATED_LINE,
   DEFAULT_OUTPUT_FILENAME,
 } from "./constants";
-import { GIT_CMD_DIFF, GIT_CMD_ROOT, GIT_CMD_UNTRACKED } from "./git-constants";
+import { GIT_CMD_ROOT } from "./git-constants";
 import { tooLargeSkipped, binarySkipped, readError } from "./strings";
 
 const exec = promisify(cpExec);
@@ -35,6 +36,10 @@ export interface Options {
   promptTemplate?: string; // inline template text
   promptTemplateFile?: string; // absolute path to a template file
   templatePreset?: "default" | "minimal" | "ja" | string; // future-proof
+  /** Git pathspec-style excludes; e.g. ["dist", "*.lock", "node_modules/"] */
+  exclude?: string[];
+  /** A file that lists excludes (one per line). Absolute or relative to repo root. */
+  excludeFile?: string;
 }
 
 export const defaultOptions: Options = {
@@ -48,6 +53,8 @@ export const defaultOptions: Options = {
 
 export function parseArgs(argv: string[]): Partial<Options> {
   const out: Partial<Options> = {};
+  const excludes: string[] = [];
+
   for (const a of argv.slice(2)) {
     if (a.startsWith("--lines=")) out.maxConsoleLines = Number(a.split("=")[1]);
     else if (a === "--no-untracked") out.includeUntracked = false;
@@ -62,7 +69,14 @@ export function parseArgs(argv: string[]): Partial<Options> {
       out.promptTemplate = a.slice("--template=".length);
     else if (a.startsWith("--template-preset="))
       out.templatePreset = a.split("=")[1]!;
+    else if (a.startsWith("--exclude=")) {
+      const v = a.slice("--exclude=".length).trim();
+      if (v) excludes.push(v);
+    } else if (a.startsWith("--exclude-file=")) {
+      out.excludeFile = a.split("=")[1]!;
+    }
   }
+  if (excludes.length) out.exclude = excludes;
 
   return out;
 }
@@ -101,12 +115,78 @@ export function renderTemplate(
   });
 }
 
+/** Read lines from a file, trim, drop comments (# ...) and blanks. */
+async function readLinesIfExists(path: string): Promise<string[]> {
+  const txt = await readTextFileIfExists(path);
+  if (!txt) return [];
+
+  return txt
+    .split(/\r?\n/g)
+    .map((s) => s.replace(/\s+#.*$/, "").trim())
+    .filter(Boolean);
+}
+
+function isAbsolutePathLike(p: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith("\\\\") || p.startsWith("/");
+}
+function toGitSlash(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+function shellQuote(s: string): string {
+  // double-quote and escape embedded quotes for cmd/sh
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+/** Build git pathspec array: [".", ":(exclude)foo", ":(exclude)bar"] */
+async function buildPathspec(
+  repoRoot: string,
+  opt: Options
+): Promise<string[]> {
+  const patterns = new Set<string>();
+  for (const p of opt.exclude ?? []) patterns.add(p);
+  if (opt.excludeFile) {
+    const abs = isAbsolutePathLike(opt.excludeFile)
+      ? opt.excludeFile
+      : join(repoRoot, opt.excludeFile);
+    for (const line of await readLinesIfExists(abs)) patterns.add(line);
+  }
+  if (patterns.size === 0) return ["."];
+
+  return ["."].concat([...patterns].map((p) => `:(exclude)${toGitSlash(p)}`));
+}
+
+async function buildDiffCommands(
+  repoRoot: string,
+  opt: Options
+): Promise<string[]> {
+  const ps = await buildPathspec(repoRoot, opt);
+  const psQuoted = ps.map(shellQuote).join(" ");
+
+  return [`git diff -- ${psQuoted}`, `git diff --cached -- ${psQuoted}`];
+}
+
+async function buildUntrackedCommand(
+  repoRoot: string,
+  opt: Options
+): Promise<string> {
+  const ps = await buildPathspec(repoRoot, opt);
+  const psQuoted = ps.map(shellQuote).join(" ");
+
+  return `git ls-files --others --exclude-standard -- ${psQuoted}`;
+}
+
 export async function collectDiff(opt: Options): Promise<string> {
-  const diff = await runGit(GIT_CMD_DIFF, opt);
-  let full = diff.trim();
+  // Resolve repo root for pathspec resolution and exclude-file
+  const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
+
+  const [diffCmd, diffCachedCmd] = await buildDiffCommands(repoRoot, opt);
+  const unstaged = await runGit(diffCmd, opt);
+  const staged = await runGit(diffCachedCmd, opt);
+  let full = (unstaged + staged).trim();
 
   if (opt.includeUntracked) {
-    const filesStdout = await runGit(GIT_CMD_UNTRACKED, opt);
+    const untrackedCmd = await buildUntrackedCommand(repoRoot, opt);
+    const filesStdout = await runGit(untrackedCmd, opt);
     const files = filesStdout
       .split("\n")
       .map((s) => s.trim())
@@ -170,6 +250,7 @@ export async function main() {
   }
 
   try {
+    // Validate git repo (leave constant in use)
     await runGit(GIT_CMD_ROOT, merged);
 
     const patchContent = await collectDiff(merged);


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

Introduce untracked-file **exclude rules** to `diff2prompt` via two new CLI flags and matching config fields:

* `--exclude=<GLOB>` (repeatable)
* `--exclude-file=<PATH>` (one-per-line patterns, `#` for comments)

The implementation builds Git **pathspec** filters (`.(exclude)pattern`) for both `git diff` and `git ls-files`, supports patterns with spaces, and resolves relative paths against the repo root. Documentation and tests updated accordingly.

## 🧐 Motivation and Background

Large repos often contain generated assets (e.g., `dist/`, `node_modules/`, `logs/`) that create noisy prompts when included as “untracked files.” Allowing users to exclude these with familiar glob-like patterns keeps prompts concise, improves performance, and prevents accidental leakage of bulky files.

## ✅ Changes

* [x] **Feature added**: `--exclude` and `--exclude-file` flags; config: `exclude: string[]`, `excludeFile: string`.
* [x] **Documentation updated**: README now documents flags, config examples, and usage snippets.
* [x] **Refactored**: Introduced helpers to build pathspecs, quote arguments, normalize/resolve paths, and read exclude files safely.
* [x] **Tests added/updated**: Flow & unit tests covering exclude logic, env/config precedence, pathspec building, and error branches.

### Code Highlights

* **CLI parsing** (`parseArgs`): collects repeated `--exclude` flags; reads `--exclude-file`.
* **Config normalization** (`normalizeUserConfig`): resolves `excludeFile` relative to repo root (if not absolute). New `pickStringArray` utility.
* **Pathspec**: `buildPathspec()` composes `[".", ":(exclude)pattern..."]` using repo-root–relative resolution for `excludeFile` entries.
* **Quoting & portability**: `shellQuote()` wraps patterns with spaces; `toGitSlash()` normalizes separators.
* **Git calls**: diffs are built from `git diff -- …` and `git diff --cached -- …`; untracked files via `git ls-files --others --exclude-standard -- …` (all with pathspecs).
* **Tests**: Expanded `child_process` mock to understand dynamic commands and apply filtering. Added cases for absolute/relative `excludeFile`, patterns with spaces, and non-Error thrown values.

## 💡 Notes / Screenshots

* Patterns accept simple wildcards (`*`, `?`) and directory prefixes (e.g., `node_modules/`). `**` is treated as a deep match in test helpers.
* Lines beginning with `#` in `exclude-file` are comments; blank lines ignored.
* No breaking changes: defaults remain unchanged if exclude options are not provided.

## 🔄 Testing

* [x] `bun run test` — Added/updated unit & flow tests:

  * CLI parsing of multiple `--exclude` and `--exclude-file`.
  * Config env/file precedence for `exclude` fields.
  * Exclusion behavior for `dist`, `node_modules/`, globs like `*.lock`, and spaced paths like `"build dir/"`.
  * Missing `excludeFile` path returns empty patterns (no filtering).
* [x] Manual verification

  1. Create untracked files: `dist/a.txt`, `node_modules/x.js`, `src/ok.txt`.
  2. Run: `diff2prompt --exclude=dist --exclude=node_modules/ --out=.tmp/prompt.txt` → prompt includes only `src/ok.txt`.
  3. Create `.d2p-ex.txt` with `logs` and rerun with `--exclude-file=.d2p-ex.txt` → `logs/*` omitted.
* [x] Linting: `bun run lint` passes.

---

### Migration / Usage Notes

* Optional config in `diff2prompt.config.json`/`.rc`:

  ```json
  {
    "exclude": ["dist", "node_modules", "*.log"],
    "excludeFile": ".gitignore"
  }
  ```
* CLI examples:

  ```bash
  diff2prompt --exclude=dist --exclude=node_modules/
  diff2prompt --exclude="build dir/"
  diff2prompt --exclude-file=.d2p-excludes
  ```
