### PR TITLE
docs(test): translate JP comments to EN; remove banner headers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-// ===== src/config.ts =====
 import { exec as cpExec } from "child_process";
 import { readFile } from "fs/promises";
 import { join } from "path";

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -1,4 +1,3 @@
-// ===== src/generate-prompt-from-git-diff.ts =====
 import { exec as cpExec } from "child_process";
 import { readFile, writeFile, stat } from "fs/promises";
 import { join } from "path";


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Translated Japanese comments in tests to English
* Removed redundant banner-style file headers

## 🧐 Motivation and Background

* Ensure consistency of codebase by using only English comments
* Simplify files by removing unnecessary banner comments

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [x] Documentation updated

## 💡 Notes / Screenshots

* Focused only on comment translation and cleanup

## 🔄 Testing

* [x] `bun run lint` passed
* [x] `bun run test` passed
* [x] Manual verification completed
