### PR TITLE
chore(build): update diff2prompt command to exclude files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint \"**/*.ts\"",
     "lint:fix": "eslint \"**/*.ts\" --fix",
     "typecheck": "tsc --noEmit",
-    "diff2prompt": "bun run src/index.ts"
+    "diff2prompt": "bun run src/index.ts --exclude=bun.lock --excludeFile=.gitignore"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Update `package.json` to refine the diff output command used by **diff2prompt**:

  * Change `diff2prompt` script from `bun run src/index.ts` to:

    * `bun run src/index.ts --exclude=bun.lock --excludeFile=.gitignore`
  * This ensures the generated diff output file excludes `bun.lock` and respects ignore patterns from `.gitignore`.

## 🧐 Motivation and Background

* The diff output occasionally included noise (e.g., lockfiles and files already ignored by Git), which made prompts verbose and less readable.
* Excluding `bun.lock` and honoring `.gitignore` improves signal-to-noise, reduces prompt size, and speeds up local runs.
* Keeps the produced prompt deterministic and focused on meaningful source changes.

## ✅ Changes

* `package.json`:

  * Updated `scripts.diff2prompt` to add `--exclude=bun.lock` and `--excludeFile=.gitignore` flags.

* No source code changes; behavior only affects how diffs are collected for prompt generation.

* [ ] Feature added

* [ ] Bug fixed

* [x] Refactored (build/tooling command refinement)

* [ ] Documentation updated

## 💡 Notes / Screenshots

* N/A

## 🔄 Testing

* Sanity check: run `pnpm diff2prompt` (or `bun run src/index.ts --exclude=bun.lock --excludeFile=.gitignore`) in a repo with:

  * `bun.lock` present → verify it is not included in the generated diff output.
  * Files and directories listed in `.gitignore` → verify they are excluded from the diff output.

* Negative case: temporarily remove `--excludeFile=.gitignore` → confirm ignored files appear again to validate the flag effect.

* Size check: compare output size before vs after to ensure reduction when ignored files existed.

* [ ] `bun run lint` passed

* [ ] `bun run test` passed

* [ ] Manual verification completed
