### PR TITLE
update: Generalize ChatGPT wording to AI; rename preview header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/watanabe-1/diff2prompt)
 
-Turn your local Git changes into a clean, copy-pastable prompt for ChatGPT (including a **commit message**, **PR title**, and **branch name** suggestion).
+Turn your local Git changes into a clean, copy-pastable prompt for **any AI assistant** (including a **commit message**, **PR title**, and **branch name** suggestion).
 
 > ✅ Works with staged & unstaged diffs, optionally includes new/untracked files (with binary/huge-file safeguards), prints a console preview, and writes the full prompt to a file.
 > 🎨 Supports **custom prompt templates** (inline, file-based, or preset).
@@ -27,7 +27,7 @@ By default, the tool:
 
 - Reads your current repo’s diffs (`git diff` & `git diff --cached`)
 - Optionally appends the contents of **untracked** files
-- Generates a structured prompt that asks ChatGPT to output:
+- Generates a structured prompt that asks the AI to output:
   - **Commit message** (Conventional Commits)
   - **PR title** (mirrors the commit)
   - **Branch name** (scoped kebab-case)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 /** Header shown before previewing the generated prompt. */
-export const PREVIEW_HEADER = "\n--- Prompt for ChatGPT (preview) ---\n";
+export const PREVIEW_HEADER = "\n--- Prompt (preview) ---\n";
 
 /** Separator header before listing new/untracked files. */
 export const NEW_FILES_HEADER = "\n\n--- New files (contents) ---\n";

--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -311,7 +311,7 @@ describe("generate.ts flow", () => {
     );
 
     const logs = logSpy.mock.calls.flat().join("\n");
-    expect(logs).toContain("--- Prompt for ChatGPT (preview) ---");
+    expect(logs).toContain("--- Prompt (preview) ---");
     expect(logs).toContain("... (truncated) ...");
     expect(logs).toContain("Prompt written to: OUT.txt");
   });
@@ -370,7 +370,7 @@ describe("generate.ts flow", () => {
       const prompt = ["line1", "line2"].join("\n");
       printPreview(prompt, /* maxLines*/ 5); // 2 <= 5 → non-truncation
       const logs = logSpy2.mock.calls.flat().join("\n");
-      expect(logs).toContain("--- Prompt for ChatGPT (preview) ---");
+      expect(logs).toContain("--- Prompt (preview) ---");
       expect(logs).toContain("line1");
       expect(logs).toContain("line2");
       expect(logs).not.toContain("... (truncated) ...");


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Generalized references from ChatGPT to AI assistants in README
* Updated preview header constant and related test expectations

## 🧐 Motivation and Background

* Broadened wording to avoid ChatGPT-specific assumptions
* Improved clarity and neutrality in preview output

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [x] Refactored
* [x] Documentation updated

## 💡 Notes / Screenshots

* Preview header now shows `--- Prompt (preview) ---`
* README refers to **any AI assistant** instead of ChatGPT

## 🔄 Testing

* [x] `bun run lint` passed
* [x] `bun run test` passed
* [x] Manual verification completed
