### PR TITLE
feat(template): embed PR template via flags and auto-discovery

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -414,7 +414,6 @@ describe("normalizeUserConfig (template fields)", () => {
     expect(cfg.templatePreset).toBe("minimal");
   });
 
-  // --- NEW: includePrTemplate / prTemplateFile ---
   it("captures includePrTemplate boolean", () => {
     const cfg = normalizeUserConfig(
       rec({ includePrTemplate: false }),
@@ -463,7 +462,6 @@ describe("loadUserConfig (template fields precedence across sources)", () => {
     expect(cfg.templatePreset).toBeUndefined();
   });
 
-  // --- NEW: precedence for prTemplateFile / includePrTemplate ---
   it("env config wins for prTemplateFile / includePrTemplate", async () => {
     putFile("C:/repo/diff2prompt.config.json", {
       prTemplateFile: "repo.md",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,8 @@ export type UserConfig = Partial<{
   maxBuffer: number;
   promptTemplate?: string; // inline template text
   promptTemplateFile?: string; // absolute path to a template file
+  includePrTemplate?: boolean;
+  prTemplateFile?: string; // absolute or repo-root relative
   templatePreset?: "default" | "minimal" | "ja" | string; // future-proof
   /** Git pathspec-style excludes; array in config */
   exclude?: string[];
@@ -179,6 +181,8 @@ export function normalizeUserConfig(
   const maxBuffer = pickNumber(cfgRaw, "maxBuffer");
   const promptTemplate = pickString(cfgRaw, "promptTemplate");
   const promptTemplateFile = pickString(cfgRaw, "promptTemplateFile");
+  const includePrTemplate = pickBoolean(cfgRaw, "includePrTemplate");
+  const prTemplateFile = pickString(cfgRaw, "prTemplateFile");
   const templatePreset = pickString(cfgRaw, "templatePreset");
 
   if (typeof maxConsoleLines === "number")
@@ -193,6 +197,13 @@ export function normalizeUserConfig(
     out.promptTemplateFile = isAbsolutePath(promptTemplateFile)
       ? promptTemplateFile
       : join(baseDir, promptTemplateFile);
+  }
+  if (typeof includePrTemplate === "boolean")
+    out.includePrTemplate = includePrTemplate;
+  if (typeof prTemplateFile === "string" && prTemplateFile.trim()) {
+    out.prTemplateFile = isAbsolutePath(prTemplateFile)
+      ? prTemplateFile
+      : join(baseDir, prTemplateFile);
   }
   if (typeof templatePreset === "string") out.templatePreset = templatePreset;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,6 +67,13 @@ Please generate **all** of the following based on the diff:
 Commit message: <type>(<optional-scope>): <message>
 PR title: <type>(<optional-scope>): <message>
 Branch: <type>[/<scope>]/<short-kebab-slug>
+
+---
+### Pull Request Template
+Fill this out based on the changes above.
+⚠️ When outputting the PR template, please render it inside a **canvas or editable area** so it can be easily filled in:
+
+{{prTemplate}}
 `.trim(),
 
   minimal: `
@@ -83,5 +90,12 @@ Please output:
 
 差分:
 {{diff}}
+
+---
+### Pull Request Template
+以下のテンプレートを埋めてください。
+⚠️ PRテンプレートの内容を出力する際は、**キャンバスや編集可能なエリア**に出力してください:
+
+{{prTemplate}}
 `.trim(),
 });

--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -449,7 +449,8 @@ describe("generate.ts flow", () => {
     process.argv = ["node", "script"]; // no --out
     await main();
 
-    // 「出力ファイル名の join 呼び出し」があったことを確認（最後の呼び出しに依存しない）
+    // Confirm that there was a "join call for the output file name"
+    // (does not rely on the last call)
     const outputJoinCall = (joinSpy.mock.calls as unknown as unknown[][]).find(
       (a: unknown[]): a is [string, string] =>
         Array.isArray(a) &&
@@ -461,12 +462,14 @@ describe("generate.ts flow", () => {
 
     const [firstArg, secondArg] = outputJoinCall!;
     expect(secondArg).toBe("generated-prompt.txt");
-    // repoRoot は "" なので、 __DIRNAME_SAFE が使われる（空文字や /repo ではない）
+    // Since repoRoot is "", __DIRNAME_SAFE should be used
+    // (not an empty string or /repo)
     expect(firstArg).not.toBe("");
     expect(firstArg).not.toBe("/repo");
 
-    // 実際に書き出されたパスも確認
+    // Also check the actually written path
     const lastWrite = fsState.writes.at(-1)!;
+
     expect(lastWrite.path.endsWith("generated-prompt.txt")).toBe(true);
   });
 
@@ -599,9 +602,9 @@ describe("generate.ts flow", () => {
 
     const out = fsState.writes.at(-1)!;
     expect(out.data).toContain("### Pull Request Template");
-    // 注意書き（キャンバス/編集可能エリア）を含む
+    // Includes the note (canvas/editable area)
     expect(out.data).toMatch(/editable area|キャンバス|編集可能なエリア/i);
-    expect(out.data).toContain("# Pull Request Template"); // 本文が埋め込まれている
+    expect(out.data).toContain("# Pull Request Template"); // The body is embedded
   });
 
   it("main(): --pr-template-file uses the given file and embeds its content", async () => {
@@ -666,7 +669,8 @@ describe("generate.ts flow", () => {
 
     const out = fsState.writes.at(-1)!;
     expect(out.data).not.toContain("PR CONTENT");
-    // default presetはセクション自体が出るが中身は空文字になる可能性があるため、強めに不在を確認
+    // Since the default preset may output the section itself but leave its contents empty,
+    // strongly assert that the content is absent
     expect(out.data).not.toMatch(/### Pull Request Template[\s\S]*PR CONTENT/);
   });
 
@@ -681,7 +685,7 @@ describe("generate.ts flow", () => {
       loadUserConfig: vi.fn().mockResolvedValue({ templatePreset: "minimal" }),
     }));
 
-    // PR テンプレートが存在しても minimal にはセクション見出しが無い
+    // Even if a PR template exists, the minimal preset does not include a section heading
     fsState.files.set("/repo/.github/pull_request_template.md", {
       size: 10,
       buf: Buffer.from("PRX", "utf8"),

--- a/src/generate-prompt-from-git-diff.unit.test.ts
+++ b/src/generate-prompt-from-git-diff.unit.test.ts
@@ -168,16 +168,16 @@ describe("renderTemplate", () => {
 
 describe("loadPrTemplateText (absolute/relative path branches)", () => {
   it("returns template text when prTemplateFile is an absolute path", async () => {
-    // モックされた fs の readFile を一時的にこのテスト用の戻り値にする
+    // Temporarily set the mocked fs.readFile to return this test value
     const fsmod = await import("fs/promises");
     const readFileMock = fsmod.readFile as unknown as ReturnType<typeof vi.fn>;
 
-    // loadPrTemplateText 内では 1回だけ readFile('utf8') が呼ばれる想定
+    // In loadPrTemplateText, readFile('utf8') is expected to be called exactly once
     readFileMock.mockResolvedValueOnce("ABS TEMPLATE");
 
     const mod = await import("../src/generate-prompt-from-git-diff");
     const txt = await mod.loadPrTemplateText("C:/repo", {
-      prTemplateFile: "C:/abs/pull_request_template.md", // 絶対パス → isAbsolutePathLike === true 分岐
+      prTemplateFile: "C:/abs/pull_request_template.md", // Absolute path → branch where isAbsolutePathLike === true
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
@@ -192,7 +192,7 @@ describe("loadPrTemplateText (absolute/relative path branches)", () => {
 
     const mod = await import("../src/generate-prompt-from-git-diff");
     const txt = await mod.loadPrTemplateText("C:/repo", {
-      prTemplateFile: ".github/pull_request_template.md", // 相対パス → join(repoRoot, ...) 分岐
+      prTemplateFile: ".github/pull_request_template.md", // Relative path → branch that uses join(repoRoot, ...)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Implement PR template embedding into generated prompt
* Add `includePrTemplate` and `prTemplateFile` options
* Auto-discover common PR template paths

## 🧐 Motivation and Background

* Streamline PR preparation by surfacing repo PR template directly in the prompt output
* Allow explicit file selection and easy opt-out via CLI/config

## ✅ Changes

* [x] Feature added: PR template embedding with auto-discovery
* [x] CLI flags: `--no-pr-template`, `--pr-template-file=<path>`
* [x] Config keys: `includePrTemplate`, `prTemplateFile`
* [x] Template presets updated to include `{{prTemplate}}` slot (default/ja)
* [x] Tests added/updated (flow + unit)
* [ ] Documentation updated (README)

## 💡 Notes / Screenshots

* `minimal` preset intentionally omits the PR section header
* Auto-discovery checks: `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `docs/pull_request_template.md`, `pull_request_template.md`

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
