### PR TITLE
chore(vscode): Switch workspace tooling to Oxc [v0.0.11]

### DIFF
--- a/.vscode/diff2prompt.code-workspace
+++ b/.vscode/diff2prompt.code-workspace
@@ -5,47 +5,50 @@
     },
   ],
   "settings": {
+    "diffEditor.ignoreTrimWhitespace": false,
     "editor.bracketPairColorization.enabled": true,
     "editor.guides.bracketPairs": "active",
-    "eslint.format.enable": false,
-    "eslint.enable": true,
     "editor.formatOnSave": true,
     "editor.formatOnType": true,
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "always",
-      "source.addMissingImports": "always",
-    },
-    "markuplint.enable": true,
-    "[javascript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-    },
-    "[json]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-    },
-    "[typescript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-    },
-    "[typescriptreact]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-    },
+    "editor.formatOnSaveMode": "file",
     "editor.lineNumbers": "on",
     "editor.rulers": [80],
     "editor.wordWrap": "on",
-    "files.insertFinalNewline": true,
-    "typescript.enablePromptUseWorkspaceTsdk": true,
-    "typescript.preferences.importModuleSpecifier": "non-relative",
-    "files.autoGuessEncoding": true,
-    "[html]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.oxc": "always",
+    },
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "[javascript]": {
+      "editor.defaultFormatter": "oxc.oxc-vscode",
+    },
+    "[json]": {
+      "editor.defaultFormatter": "oxc.oxc-vscode",
     },
     "[jsonc]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "editor.defaultFormatter": "oxc.oxc-vscode",
+    },
+    "[typescript]": {
+      "editor.defaultFormatter": "oxc.oxc-vscode",
+    },
+    "[typescriptreact]": {
+      "editor.defaultFormatter": "oxc.oxc-vscode",
+    },
+    "[html]": {
+      "editor.defaultFormatter": "oxc.oxc-vscode",
     },
     "[markdown]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "editor.defaultFormatter": "oxc.oxc-vscode",
     },
-    "diffEditor.ignoreTrimWhitespace": false,
-    "javascript.updateImportsOnFileMove.enabled": "always",
+    "markuplint.enable": true,
+    "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.preferences.importModuleSpecifier": "non-relative",
+    "js/ts.updateImportsOnFileMove.enabled": "always",
+    "json.schemaDownload.enable": true,
+    "json.schemaDownload.trustedDomains": {
+      "https://docs.renovatebot.com/": true,
+    },
+    "files.insertFinalNewline": true,
+    "files.autoGuessEncoding": true,
     "files.eol": "\n",
   },
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint", // ESLint
-    "esbenp.prettier-vscode", // Prettier
+    "oxc.oxc-vscode", // Oxc
     "yusukehirao.vscode-markuplint", // Markuplint
     "davidanson.vscode-markdownlint" // Markdownlint
   ]


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Updated VS Code workspace settings to use Oxc as the default formatter and fix-all provider.
* Replaced ESLint and Prettier extension recommendations with the Oxc extension.
* Added editor and JSON schema-related workspace settings.

## 🧐 Motivation and Background

* Align workspace tooling with the Oxc/Oxlint/Oxfmt migration.
* Reduce reliance on ESLint and Prettier for editor-level formatting and auto-fix behavior.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Tool configuration updated

## 💡 Notes / Screenshots

* No screenshots.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
