### PR TITLE
fix(diff): Reject empty diffs when untracked files are excluded [v0.0.11]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -307,6 +307,18 @@ describe("generate.ts flow", () => {
     expect(s).not.toContain("New files (contents)");
   });
 
+  it("collectDiff(): rejects with --no-untracked when staged and unstaged diffs are empty", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("");
+    gitMap.setStaged("");
+    gitMap.setUntracked("a.txt\n");
+
+    const { collectDiff, defaultOptions } = await importSut();
+    await expect(collectDiff({ ...defaultOptions, includeUntracked: false })).rejects.toThrow(
+      "No changes found: neither diffs nor new files.",
+    );
+  });
+
   it("collectDiff(): --max-new-size forces skip", async () => {
     gitMap.setUnstaged("");
     gitMap.setStaged("");

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -190,7 +190,6 @@ export async function collectDiff(opt: Options): Promise<string> {
         }
       }
     }
-
   }
 
   if (!full.trim()) {

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -191,9 +191,10 @@ export async function collectDiff(opt: Options): Promise<string> {
       }
     }
 
-    if (!full.trim()) {
-      throw new Error(ERROR_NO_CHANGES);
-    }
+  }
+
+  if (!full.trim()) {
+    throw new Error(ERROR_NO_CHANGES);
   }
 
   return full;


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Fixed `collectDiff()` so it rejects when staged and unstaged diffs are empty, even if untracked files exist but are excluded with `--no-untracked`.

## 🧐 Motivation and Background

* Previously, the no-changes validation was scoped inside the untracked-files collection block, so `--no-untracked` could skip the empty-diff error path.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Not applicable

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
