### PR TITLE
fix(security): Use execFile for git commands [v0.0.12]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,5 +11,5 @@
 *.yml         text eol=lf
 *.yaml        text eol=lf
 *.lock        text eol=lf
-.code-workspace text eol=lf
+*.code-workspace text eol=lf
 .gitignore    text eol=lf

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -40,7 +40,11 @@ vi.mock("child_process", async () => {
     shape: "string" as "string" | "array" | "object",
   });
 
-  function rawExec(_cmd: string, cb?: (err: unknown, stdout: string, stderr: string) => void) {
+  function rawExecFile(
+    _file: string,
+    _args: string[],
+    cb?: (err: unknown, stdout: string, stderr: string) => void,
+  ) {
     if (execState.throws) {
       const err = new Error("fail");
       cb?.(err, "", "");
@@ -53,7 +57,7 @@ vi.mock("child_process", async () => {
   }
 
   // Key point: switch the return "shape" via promisify.custom
-  (rawExec as any)[promisify.custom] = (_: string) => {
+  (rawExecFile as any)[promisify.custom] = (_file: string, _args: string[]) => {
     if (execState.throws) {
       return Promise.reject(new Error("fail"));
     }
@@ -67,7 +71,7 @@ vi.mock("child_process", async () => {
     }
   };
 
-  return { exec: rawExec };
+  return { execFile: rawExecFile };
 });
 
 vi.mock("path", async (orig) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { exec as cpExec } from "child_process";
+import { execFile as cpExecFile } from "child_process";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { promisify } from "util";
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import { DEFAULT_OUTPUT_FILENAME } from "./constants";
 import type { Options } from "./generate-prompt-from-git-diff";
 
-const exec = promisify(cpExec);
+const execFile = promisify(cpExecFile);
 
 export type UserConfig = Partial<{
   outputPath: string;
@@ -54,7 +54,7 @@ type StringArrayKeys<T, IncludeOptional extends boolean = true> = KeysByType<
 
 export async function getRepoRootSafe(): Promise<string | null> {
   try {
-    const res = await exec("git rev-parse --show-toplevel");
+    const res = await execFile("git", ["rev-parse", "--show-toplevel"]);
 
     // Handle possible shapes from promisified exec:
     // - string                => stdout

--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -25,7 +25,11 @@ const gitMap = vi.hoisted(() => ({
 const fsState = vi.hoisted(() => ({
   files: new Map<string, { size: number; buf?: Buffer; err?: Error }>(),
   writes: [] as Array<{ path: string; data: string; enc?: string }>,
-  execCalls: [] as Array<{ cmd: string; opts?: { cwd?: string; maxBuffer?: number } }>,
+  execCalls: [] as Array<{
+    file: string;
+    args: string[];
+    opts?: { cwd?: string; maxBuffer?: number };
+  }>,
   reset() {
     this.files.clear();
     this.writes.length = 0;
@@ -34,17 +38,24 @@ const fsState = vi.hoisted(() => ({
 }));
 
 // ---- child_process mock ----
-// New logic: git commands are dynamic (with pathspec), so dispatch by prefix match.
+// New logic: git commands are dynamic (with pathspec), so dispatch by argv shape.
 vi.mock("child_process", () => {
   type ExecCb = (error: Error | null, stdout?: string, stderr?: string) => void;
 
-  function resolveKey(cmd: string): "ROOT" | "UNSTAGED" | "STAGED" | "UNTRACKED" | string {
-    if (cmd.startsWith("git rev-parse --show-toplevel")) return "ROOT";
-    if (cmd.startsWith("git diff --cached -- ")) return "STAGED";
-    if (cmd.startsWith("git diff -- ")) return "UNSTAGED";
-    if (cmd.startsWith("git ls-files --others --exclude-standard -- ")) return "UNTRACKED";
+  function resolveKey(args: string[]): "ROOT" | "UNSTAGED" | "STAGED" | "UNTRACKED" | string {
+    if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return "ROOT";
+    if (args[0] === "diff" && args[1] === "--cached" && args[2] === "--") return "STAGED";
+    if (args[0] === "diff" && args[1] === "--") return "UNSTAGED";
+    if (
+      args[0] === "ls-files" &&
+      args[1] === "--others" &&
+      args[2] === "--exclude-standard" &&
+      args[3] === "--"
+    ) {
+      return "UNTRACKED";
+    }
 
-    return cmd; // fallback (not expected)
+    return args.join(" "); // fallback (not expected)
   }
 
   // --- pathspec helpers ----
@@ -61,35 +72,12 @@ vi.mock("child_process", () => {
     return new RegExp("^" + g + "$");
   }
 
-  function parseExcludesFromCmd(cmd: string): string[] {
-    const idx = cmd.indexOf(" -- ");
+  function parseExcludesFromArgs(args: string[]): string[] {
+    const idx = args.indexOf("--");
     if (idx < 0) return [];
-    const tail = cmd.slice(idx + 4).trim();
 
-    const tokens: string[] = [];
-    let cur = "";
-    let inQ = false;
-
-    for (let i = 0; i < tail.length; i++) {
-      const ch = tail[i];
-
-      if (ch === '"') {
-        inQ = !inQ;
-        continue;
-      }
-
-      if (!inQ && /\s/.test(ch)) {
-        if (cur.length) {
-          tokens.push(cur);
-          cur = "";
-        }
-        continue;
-      }
-      cur += ch;
-    }
-    if (cur.length) tokens.push(cur);
-
-    return tokens
+    return args
+      .slice(idx + 1)
       .filter((t) => t.startsWith(":(exclude)"))
       .map((t) => t.slice(":(exclude)".length));
   }
@@ -127,17 +115,17 @@ vi.mock("child_process", () => {
     return out;
   }
 
-  function coreExecBehavior(cmd: string): {
+  function coreExecBehavior(args: string[]): {
     cbError: Error | null;
     promiseReject: Error | string | null;
     stdout: string;
     stderr: string;
   } {
-    const key = resolveKey(cmd);
+    const key = resolveKey(args);
     let out = gitMap.data.get(key) ?? "";
 
     if (key === "UNTRACKED") {
-      const excludes = parseExcludesFromCmd(cmd);
+      const excludes = parseExcludesFromArgs(args);
       out = filterListByExcludes(out, excludes);
     }
 
@@ -166,31 +154,34 @@ vi.mock("child_process", () => {
     };
   }
 
-  function exec(
-    cmd: string,
+  function execFile(
+    file: string,
+    args: string[],
     optionsOrCb?: { cwd?: string; maxBuffer?: number } | ExecCb,
     maybeCb?: ExecCb,
   ): ChildProcess {
     const cb: ExecCb | undefined = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
-    if (typeof optionsOrCb !== "function") fsState.execCalls.push({ cmd, opts: optionsOrCb });
+    if (typeof optionsOrCb !== "function") {
+      fsState.execCalls.push({ file, args, opts: optionsOrCb });
+    }
 
-    const { cbError, stdout, stderr } = coreExecBehavior(cmd);
+    const { cbError, stdout, stderr } = coreExecBehavior(args);
     cb?.(cbError, stdout, stderr);
 
     return {} as ChildProcess;
   }
 
-  const custom = (cmd: string, opts?: { cwd?: string; maxBuffer?: number }) =>
+  const custom = (file: string, args: string[], opts?: { cwd?: string; maxBuffer?: number }) =>
     new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-      fsState.execCalls.push({ cmd, opts });
-      const { promiseReject, stdout, stderr } = coreExecBehavior(cmd);
+      fsState.execCalls.push({ file, args, opts });
+      const { promiseReject, stdout, stderr } = coreExecBehavior(args);
       if (promiseReject !== null) reject(promiseReject);
       else resolve({ stdout, stderr });
     });
 
-  (exec as any)[util.promisify.custom] = custom;
+  (execFile as any)[util.promisify.custom] = custom;
 
-  return { exec };
+  return { execFile };
 });
 
 // ---- fs/promises mock ----
@@ -330,10 +321,14 @@ describe("generate.ts flow", () => {
       expect(s).toContain("created");
 
       const collectGitCalls = fsState.execCalls.filter(
-        ({ cmd }) =>
-          cmd.startsWith("git diff -- ") ||
-          cmd.startsWith("git diff --cached -- ") ||
-          cmd.startsWith("git ls-files --others --exclude-standard -- "),
+        ({ file, args }) =>
+          file === "git" &&
+          ((args[0] === "diff" && args[1] === "--") ||
+            (args[0] === "diff" && args[1] === "--cached" && args[2] === "--") ||
+            (args[0] === "ls-files" &&
+              args[1] === "--others" &&
+              args[2] === "--exclude-standard" &&
+              args[3] === "--")),
       );
       expect(collectGitCalls.map(({ opts }) => opts?.cwd)).toEqual([
         "C:/repo",
@@ -873,7 +868,7 @@ describe("generate.ts flow", () => {
     expect(s).not.toContain("File: logs/a.log");
   });
 
-  it("collectDiff(): --exclude supports patterns with spaces (shellQuote path)", async () => {
+  it("collectDiff(): --exclude supports patterns with spaces", async () => {
     gitMap.setRoot("/repo\n");
     gitMap.setUnstaged("");
     gitMap.setStaged("");
@@ -891,5 +886,24 @@ describe("generate.ts flow", () => {
     expect(s).toContain("File: src/ok.txt");
     expect(s).toContain("ok");
     expect(s).not.toContain("File: build dir/a.js");
+  });
+
+  it("collectDiff(): passes shell-looking excludes as a single git argv item", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { collectDiff, defaultOptions } = await importSut();
+    await collectDiff({
+      ...defaultOptions,
+      includeUntracked: false,
+      exclude: ["$(touch injected)"],
+    });
+
+    const diffCall = fsState.execCalls.find(
+      ({ file, args }) => file === "git" && args[0] === "diff" && args[1] === "--",
+    );
+    expect(diffCall?.args).toEqual(["diff", "--", ".", ":(exclude)$(touch injected)"]);
   });
 });

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -1,4 +1,4 @@
-import { exec as cpExec } from "child_process";
+import { execFile as cpExecFile } from "child_process";
 import { readFile, writeFile, stat } from "fs/promises";
 import { join } from "path";
 import { promisify } from "util";
@@ -18,7 +18,7 @@ import {
 } from "./constants";
 import { tooLargeSkipped, binarySkipped, readError } from "./strings";
 
-const exec = promisify(cpExec);
+const execFile = promisify(cpExecFile);
 
 const __DIRNAME_SAFE =
   /* c8 ignore next */
@@ -79,8 +79,8 @@ export function parseArgs(argv: string[]): Partial<Options> {
   return out;
 }
 
-export async function runGit(cmd: string, opt: Options, cwd?: string): Promise<string> {
-  const { stdout } = (await exec(cmd, {
+export async function runGit(args: string[], opt: Options, cwd?: string): Promise<string> {
+  const { stdout } = (await execFile("git", args, {
     cwd,
     maxBuffer: opt.maxBuffer,
   })) as ExecResult;
@@ -119,10 +119,6 @@ function isAbsolutePathLike(p: string): boolean {
 function toGitSlash(p: string): string {
   return p.replace(/\\/g, "/");
 }
-function shellQuote(s: string): string {
-  // double-quote and escape embedded quotes for cmd/sh
-  return `"${s.replace(/"/g, '\\"')}"`;
-}
 
 /** Build git pathspec array: [".", ":(exclude)foo", ":(exclude)bar"] */
 async function buildPathspec(repoRoot: string, opt: Options): Promise<string[]> {
@@ -139,32 +135,33 @@ async function buildPathspec(repoRoot: string, opt: Options): Promise<string[]> 
   return ["."].concat([...patterns].map((p) => `:(exclude)${toGitSlash(p)}`));
 }
 
-async function buildDiffCommands(repoRoot: string, opt: Options): Promise<string[]> {
+async function buildDiffArgs(repoRoot: string, opt: Options): Promise<string[][]> {
   const ps = await buildPathspec(repoRoot, opt);
-  const psQuoted = ps.map(shellQuote).join(" ");
 
-  return [`git diff -- ${psQuoted}`, `git diff --cached -- ${psQuoted}`];
+  return [
+    ["diff", "--", ...ps],
+    ["diff", "--cached", "--", ...ps],
+  ];
 }
 
-async function buildUntrackedCommand(repoRoot: string, opt: Options): Promise<string> {
+async function buildUntrackedArgs(repoRoot: string, opt: Options): Promise<string[]> {
   const ps = await buildPathspec(repoRoot, opt);
-  const psQuoted = ps.map(shellQuote).join(" ");
 
-  return `git ls-files --others --exclude-standard -- ${psQuoted}`;
+  return ["ls-files", "--others", "--exclude-standard", "--", ...ps];
 }
 
 export async function collectDiff(opt: Options): Promise<string> {
   // Resolve repo root for pathspec resolution and exclude-file
   const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
 
-  const [diffCmd, diffCachedCmd] = await buildDiffCommands(repoRoot, opt);
-  const unstaged = await runGit(diffCmd, opt, repoRoot);
-  const staged = await runGit(diffCachedCmd, opt, repoRoot);
+  const [diffArgs, diffCachedArgs] = await buildDiffArgs(repoRoot, opt);
+  const unstaged = await runGit(diffArgs, opt, repoRoot);
+  const staged = await runGit(diffCachedArgs, opt, repoRoot);
   let full = (unstaged + staged).trim();
 
   if (opt.includeUntracked) {
-    const untrackedCmd = await buildUntrackedCommand(repoRoot, opt);
-    const filesStdout = await runGit(untrackedCmd, opt, repoRoot);
+    const untrackedArgs = await buildUntrackedArgs(repoRoot, opt);
+    const filesStdout = await runGit(untrackedArgs, opt, repoRoot);
     const files = filesStdout
       .split("\n")
       .map((s) => s.trim())
@@ -252,7 +249,7 @@ export async function main() {
 
   try {
     // Validate git repo (leave constant in use)
-    await runGit("git rev-parse --show-toplevel", merged);
+    await runGit(["rev-parse", "--show-toplevel"], merged);
 
     const patchContent = await collectDiff(merged);
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Replaced shell-based `exec` calls with `execFile` for git commands.
* Changed git command construction from shell strings to argv arrays.
* Updated tests to validate argv-based git execution and shell-looking exclude patterns.
* Fixed `.gitattributes` workspace file matching from `.code-workspace` to `*.code-workspace`.

## 🧐 Motivation and Background

* Avoid shell interpretation when passing git pathspecs and exclude patterns.
* Make exclude handling safer for values that look like shell commands, such as `$(touch injected)`.
* Simplify test mocks by matching git argv shapes instead of parsing shell-quoted command strings.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* No screenshots applicable.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
