### PR TITLE
fix(template): Resolve CLI template files from repo root [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -566,6 +566,48 @@ describe("generate.ts flow", () => {
     expect(out.data).not.toContain("Please generate **all** of the following");
   });
 
+  it("main(): resolves CLI --template-file relative to repo root when cwd is nested", async () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/repo/packages/app");
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF-CLI\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    await vi.doMock("./config", () => ({
+      getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
+      loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({}),
+    }));
+
+    const tpl = "CLI-FILE {{diff}} {{repoRoot}}";
+    fsState.files.set("/repo/.github/prompt.tpl.md", {
+      size: tpl.length,
+      buf: Buffer.from(tpl, "utf8"),
+    });
+
+    try {
+      const { main } = await importSut();
+      process.argv = [
+        "node",
+        "script",
+        "--template-file=.github/prompt.tpl.md",
+        "--out=/repo/OUT.txt",
+      ];
+      await main();
+
+      const fsmod = await import("fs/promises");
+      const readFileMock = fsmod.readFile as unknown as ReturnType<typeof vi.fn>;
+      const readPaths = readFileMock.mock.calls.map((call) => String(call[0]).replace(/\\/g, "/"));
+      expect(readPaths).toContain("/repo/.github/prompt.tpl.md");
+      expect(readPaths).not.toContain(".github/prompt.tpl.md");
+
+      const out = fsState.writes.at(-1)!;
+      expect(out.data).toContain("CLI-FILE DIFF-CLI /repo");
+      expect(out.data).not.toContain("Please generate **all** of the following");
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
   it("main(): template precedence CLI inline > file > preset > default", async () => {
     gitMap.setRoot("/repo\n");
     gitMap.setUnstaged("XYZ\n");

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -116,6 +116,9 @@ async function readLinesIfExists(path: string): Promise<string[]> {
 function isAbsolutePathLike(p: string): boolean {
   return /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith("\\\\") || p.startsWith("/");
 }
+function resolveRepoPath(repoRoot: string, p: string): string {
+  return isAbsolutePathLike(p) ? p : join(repoRoot, p);
+}
 function toGitSlash(p: string): string {
   return p.replace(/\\/g, "/");
 }
@@ -210,9 +213,7 @@ export function printPreview(prompt: string, maxLines: number) {
 export async function loadPrTemplateText(repoRoot: string, opt: Options): Promise<string | null> {
   // 1) Explicit path if provided
   if (opt.prTemplateFile) {
-    const p = isAbsolutePathLike(opt.prTemplateFile)
-      ? opt.prTemplateFile
-      : join(repoRoot, opt.prTemplateFile);
+    const p = resolveRepoPath(repoRoot, opt.prTemplateFile);
     const txt = await readTextFileIfExists(p);
     if (txt && txt.trim()) return txt;
   }
@@ -261,7 +262,8 @@ export async function main() {
       templateText = merged.promptTemplate.trim();
     } else if (merged.promptTemplateFile) {
       // 2) Template file
-      const txt = await readTextFileIfExists(merged.promptTemplateFile);
+      const templatePath = resolveRepoPath(repoRoot, merged.promptTemplateFile);
+      const txt = await readTextFileIfExists(templatePath);
       templateText = txt?.trim();
     }
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Resolve `--template-file` paths relative to the repository root when the CLI is run from a nested working directory.

## 🧐 Motivation and Background

* Previously, CLI template files were read relative to the current working directory, which could fail or load the wrong file when running from a subdirectory.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added `resolveRepoPath()` to share repo-root-relative path resolution.
* Added a flow test covering nested `cwd` behavior.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
