### PR TITLE
fix(exclude): Ignore commented exclude patterns [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -846,7 +846,10 @@ describe("generate.ts flow", () => {
 
     fsState.files.set("/repo/.d2p-ex.txt", {
       size: 100,
-      buf: Buffer.from(["logs", "*.tmp   # ignored", "   # comment", ""].join("\n"), "utf8"),
+      buf: Buffer.from(
+        ["logs", "*.tmp   # ignored", "# comment", "   # indented comment", ""].join("\n"),
+        "utf8",
+      ),
     });
 
     fsState.files.set("/repo/src/ok.txt", { size: 2, buf: Buffer.from("ok") });
@@ -867,6 +870,18 @@ describe("generate.ts flow", () => {
     expect(out.data).toContain("ok");
     expect(out.data).not.toContain("File: build/a.js");
     expect(out.data).not.toContain("File: logs/app.log");
+
+    const untrackedCall = fsState.execCalls.find(
+      ({ file, args }) =>
+        file === "git" &&
+        args[0] === "ls-files" &&
+        args[1] === "--others" &&
+        args[2] === "--exclude-standard",
+    );
+    expect(untrackedCall?.args).toContain(":(exclude)logs");
+    expect(untrackedCall?.args).toContain(":(exclude)*.tmp");
+    expect(untrackedCall?.args).not.toContain(":(exclude)# comment");
+    expect(untrackedCall?.args).not.toContain(":(exclude)# indented comment");
   });
 
   it("collectDiff(): excludeFile (relative) missing -> readLinesIfExists returns [] and no filtering (patterns.size===0)", async () => {

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -110,6 +110,7 @@ async function readLinesIfExists(path: string): Promise<string[]> {
   return txt
     .split(/\r?\n/g)
     .map((s) => s.replace(/\s+#.*$/, "").trim())
+    .filter((s) => !s.startsWith("#"))
     .filter(Boolean);
 }
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Updated exclude file parsing to ignore full-line comments.
* Added flow test coverage to ensure commented exclude patterns are not passed to `git ls-files`.

## 🧐 Motivation and Background

* Exclude files could previously treat full-line comments as patterns after trimming, especially indented comments.
* This change prevents comment-only lines from accidentally becoming Git exclude pathspecs.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Not applicable.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
