### PR TITLE
fix(cli): Preserve equals in flag values [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -256,6 +256,32 @@ describe("generate.ts flow", () => {
     process.env = { ...origEnv };
   });
 
+  it("parseArgs(): keeps '=' inside flag values", async () => {
+    const { parseArgs } = await importSut();
+
+    const parsed = parseArgs([
+      "node",
+      "script",
+      "--lines=10",
+      "--out=tmp/a=b.txt",
+      "--max-new-size=123",
+      "--max-buffer=456",
+      "--template-file=.github/prompt=a.tpl.md",
+      "--pr-template-file=.github/pr=a.tpl.md",
+      "--template-preset=custom=a",
+      "--exclude-file=.d2p=a.txt",
+    ]);
+
+    expect(parsed.maxConsoleLines).toBe(10);
+    expect(parsed.outputPath).toBe("tmp/a=b.txt");
+    expect(parsed.maxNewFileSizeBytes).toBe(123);
+    expect(parsed.maxBuffer).toBe(456);
+    expect(parsed.promptTemplateFile).toBe(".github/prompt=a.tpl.md");
+    expect(parsed.prTemplateFile).toBe(".github/pr=a.tpl.md");
+    expect(parsed.templatePreset).toBe("custom=a");
+    expect(parsed.excludeFile).toBe(".d2p=a.txt");
+  });
+
   it("main(): diff + untracked (text/binary/huge/error), truncated preview, writes file", async () => {
     const diff = "diff --git a/x b/x\n@@\n-1\n+2\n";
     gitMap.setRoot("/repo\n");

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -57,21 +57,25 @@ export function parseArgs(argv: string[]): Partial<Options> {
   const excludes: string[] = [];
 
   for (const a of argv.slice(2)) {
-    if (a.startsWith("--lines=")) out.maxConsoleLines = Number(a.split("=")[1]);
+    if (a.startsWith("--lines=")) out.maxConsoleLines = Number(a.slice("--lines=".length));
     else if (a === "--no-untracked") out.includeUntracked = false;
-    else if (a.startsWith("--out=")) out.outputPath = a.split("=")[1]!;
-    else if (a.startsWith("--max-new-size=")) out.maxNewFileSizeBytes = Number(a.split("=")[1]);
-    else if (a.startsWith("--max-buffer=")) out.maxBuffer = Number(a.split("=")[1]);
-    else if (a.startsWith("--template-file=")) out.promptTemplateFile = a.split("=")[1]!;
+    else if (a.startsWith("--out=")) out.outputPath = a.slice("--out=".length);
+    else if (a.startsWith("--max-new-size="))
+      out.maxNewFileSizeBytes = Number(a.slice("--max-new-size=".length));
+    else if (a.startsWith("--max-buffer=")) out.maxBuffer = Number(a.slice("--max-buffer=".length));
+    else if (a.startsWith("--template-file="))
+      out.promptTemplateFile = a.slice("--template-file=".length);
     else if (a.startsWith("--template=")) out.promptTemplate = a.slice("--template=".length);
     else if (a === "--no-pr-template") out.includePrTemplate = false;
-    else if (a.startsWith("--pr-template-file=")) out.prTemplateFile = a.split("=")[1]!;
-    else if (a.startsWith("--template-preset=")) out.templatePreset = a.split("=")[1]!;
+    else if (a.startsWith("--pr-template-file="))
+      out.prTemplateFile = a.slice("--pr-template-file=".length);
+    else if (a.startsWith("--template-preset="))
+      out.templatePreset = a.slice("--template-preset=".length);
     else if (a.startsWith("--exclude=")) {
       const v = a.slice("--exclude=".length).trim();
       if (v) excludes.push(v);
     } else if (a.startsWith("--exclude-file=")) {
-      out.excludeFile = a.split("=")[1]!;
+      out.excludeFile = a.slice("--exclude-file=".length);
     }
   }
   if (excludes.length) out.exclude = excludes;


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Fixed CLI argument parsing so `=` characters inside flag values are preserved.

## 🧐 Motivation and Background

* Previously, flags parsed with `split("=")[1]` lost content after additional `=` characters.
* This affected paths and custom values such as `--out=tmp/a=b.txt`.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Replaced `split("=")[1]` parsing with prefix-based `slice(...)`.
* Added a regression test for flags containing `=` in their values.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
