### PR TITLE
chore(package): Remove obsolete module field [v0.0.12]

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "dist"
   ],
   "type": "module",
-  "module": "dist/index.js",
   "scripts": {
     "build": "bun run clean && bun build.ts",
     "clean": "bun -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Removed the obsolete `module` field from `package.json`.

## 🧐 Motivation and Background

* The package is already configured as ESM with `"type": "module"`, and the `module` field is no longer needed.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Build/package configuration updated

## 💡 Notes / Screenshots

* Not applicable

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
