### PR TITLE
docs(prompt): Normalize branch charset notation [v0.0.12]

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,7 +57,7 @@ Please generate **all** of the following based on the diff:
 2) **PR title**: mirror the commit message exactly.
 
 3) **Branch name**:
-   - Lowercase kebab-case, ASCII [a–z0–9-] only.
+   - Lowercase kebab-case, ASCII [a-z0-9-] only.
    - Prefix "<type>/" and include "/<scope>" if used.
    - ≤ 40 chars after the prefix.
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Normalized the branch name charset notation in the prompt from `[a–z0–9-]` to `[a-z0-9-]`.

## 🧐 Motivation and Background

* To keep the character range ASCII-only and avoid using en dashes in the documented regex-like notation.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [x] Documentation updated

## 💡 Notes / Screenshots

* No screenshots needed.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
