### PR TITLE
fix(options): Fall back on whitespace output paths [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -230,6 +230,14 @@ function mockExit() {
   return { restore: () => void (process.exit = original) };
 }
 
+async function mockConfig(overrides: Record<string, unknown>) {
+  await vi.doMock("./config", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("./config")>();
+
+    return { ...actual, ...overrides };
+  });
+}
+
 describe("generate.ts flow", () => {
   const origArgv = process.argv.slice();
   const origEnv = { ...process.env };
@@ -473,10 +481,10 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({}),
-    }));
+    });
 
     const joinSpy: any = vi.fn<(a: string, b: string) => string>(
       (a: string, b: string) => `${a}/${b}`,
@@ -508,10 +516,10 @@ describe("generate.ts flow", () => {
     gitMap.setUntracked("");
 
     // Return an empty string for repoRoot → falsy → falls back to __DIRNAME_SAFE
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue(""),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({}),
-    }));
+    });
 
     // Spy join to inspect calls; mock keeps signature join(a, b)
     const joinSpy: any = vi.fn<(a: string, b: string) => string>(
@@ -551,18 +559,64 @@ describe("generate.ts flow", () => {
     expect(lastWrite.path.endsWith("generated-prompt.txt")).toBe(true);
   });
 
+  it("main(): whitespace-only --out falls back to default output path", async () => {
+    vi.resetModules();
+
+    gitMap.reset();
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    await mockConfig({
+      getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
+      loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({}),
+    });
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--out=   "];
+    await main();
+
+    const lastWrite = fsState.writes.at(-1)!;
+    expect(lastWrite.path.replace(/\\/g, "/")).toBe("/repo/generated-prompt.txt");
+  });
+
+  it("main(): whitespace-only config outputPath falls back to default output path", async () => {
+    vi.resetModules();
+
+    gitMap.reset();
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    await mockConfig({
+      getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
+      loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
+        outputPath: "   ",
+      }),
+    });
+
+    const { main } = await importSut();
+    process.argv = ["node", "script"];
+    await main();
+
+    const lastWrite = fsState.writes.at(-1)!;
+    expect(lastWrite.path.replace(/\\/g, "/")).toBe("/repo/generated-prompt.txt");
+  });
+
   it("main(): uses promptTemplateFile and replaces {{diff}}, {{now}}, {{repoRoot}}", async () => {
     gitMap.setRoot("/repo\n");
     gitMap.setUnstaged("DIFF-A\n");
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
         promptTemplateFile: "/repo/.github/prompt.tpl.md",
       }),
-    }));
+    });
 
     const tpl = [
       "# Custom Prompt",
@@ -599,10 +653,10 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({}),
-    }));
+    });
 
     const tpl = "CLI-FILE {{diff}} {{repoRoot}}";
     fsState.files.set("/repo/.github/prompt.tpl.md", {
@@ -640,13 +694,13 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
         promptTemplateFile: "/repo/tpl.md",
         templatePreset: "minimal",
       }),
-    }));
+    });
 
     const fileTpl = "FILE-TPL {{diff}}";
     fsState.files.set("/repo/tpl.md", {
@@ -675,12 +729,12 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
         templatePreset: "minimal",
       }),
-    }));
+    });
 
     const { main } = await importSut();
     process.argv = ["node", "script", "--out=/repo/PRESET.txt"];
@@ -698,10 +752,10 @@ describe("generate.ts flow", () => {
     gitMap.setUntracked("");
 
     // default preset via empty config; PR template auto-discovery
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({}),
-    }));
+    });
 
     const pr = ["# Pull Request Template", "", "## 📝 Overview", "- What was done"].join("\n");
 
@@ -728,12 +782,12 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi
         .fn<() => Promise<Record<string, unknown>>>()
         .mockResolvedValue({ templatePreset: "default" }),
-    }));
+    });
 
     const pr = "## Custom PR\n- item";
     fsState.files.set("/repo/PR.md", {
@@ -763,12 +817,12 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi
         .fn<() => Promise<Record<string, unknown>>>()
         .mockResolvedValue({ templatePreset: "default" }),
-    }));
+    });
 
     const pr = "PR CONTENT";
     fsState.files.set("/repo/.github/pull_request_template.md", {
@@ -793,13 +847,13 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
         includePrTemplate: false,
         templatePreset: "default",
       }),
-    }));
+    });
 
     fsState.files.set("/repo/.github/pull_request_template.md", {
       size: 10,
@@ -821,12 +875,12 @@ describe("generate.ts flow", () => {
     gitMap.setStaged("");
     gitMap.setUntracked("");
 
-    await vi.doMock("./config", () => ({
+    await mockConfig({
       getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
       loadUserConfig: vi
         .fn<() => Promise<Record<string, unknown>>>()
         .mockResolvedValue({ templatePreset: "minimal" }),
-    }));
+    });
 
     // Even if a PR template exists, the minimal preset does not include a section heading
     fsState.files.set("/repo/.github/pull_request_template.md", {

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile, stat } from "fs/promises";
 import { join } from "path";
 import { promisify } from "util";
 
-import { getRepoRootSafe, loadUserConfig } from "./config";
+import { getRepoRootSafe, loadUserConfig, mergeOptions } from "./config";
 import {
   MAX_CONSOLE_LINES_DEFAULT,
   MAX_NEWFILE_SIZE_BYTES,
@@ -14,7 +14,6 @@ import {
   NEW_FILES_HEADER,
   PREVIEW_HEADER,
   TRUNCATED_LINE,
-  DEFAULT_OUTPUT_FILENAME,
 } from "./constants";
 import { tooLargeSkipped, binarySkipped, readError } from "./strings";
 
@@ -243,15 +242,7 @@ export async function main() {
   const fileCfg = await loadUserConfig(repoRoot);
   const cli = parseArgs(process.argv);
 
-  const merged: Options = {
-    ...defaultOptions,
-    ...fileCfg,
-    ...cli,
-  };
-
-  if (!merged.outputPath) {
-    merged.outputPath = join(repoRoot || __DIRNAME_SAFE, DEFAULT_OUTPUT_FILENAME);
-  }
+  const merged = mergeOptions(defaultOptions, fileCfg, cli, repoRoot || null, __DIRNAME_SAFE);
 
   try {
     // Validate git repo (leave constant in use)

--- a/src/generate-prompt-from-git-diff.unit.test.ts
+++ b/src/generate-prompt-from-git-diff.unit.test.ts
@@ -107,6 +107,26 @@ describe("merge behavior (defaults -> file -> cli)", () => {
     expect(merged.outputPath.endsWith("generated-prompt.txt")).toBe(true);
   });
 
+  it("uses default filename when outputPath is whitespace only", () => {
+    const mergedFromConfig = mergeOptions(
+      defaultOptions,
+      { outputPath: "   " },
+      {},
+      "C:/repo",
+      "C:/cwd",
+    );
+    const mergedFromCli = mergeOptions(
+      defaultOptions,
+      { outputPath: "C:/repo/from-file.txt" },
+      { outputPath: "   " },
+      "C:/repo",
+      "C:/cwd",
+    );
+
+    expect(mergedFromConfig.outputPath.replace(/\\/g, "/")).toBe("C:/repo/generated-prompt.txt");
+    expect(mergedFromCli.outputPath.replace(/\\/g, "/")).toBe("C:/repo/generated-prompt.txt");
+  });
+
   it("file config supplies outputFile; CLI overrides with --out", () => {
     const fileCfg: Partial<Options> = { outputPath: "C:/repo/from-file.txt" };
     const cli = parseArgs(["node", "script", "--out=C:/tmp/cli.txt"]);


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Fall back to the default `generated-prompt.txt` output path when `outputPath` or `--out` is whitespace-only.
* Reuse `mergeOptions` in `main()` so option merging behavior stays centralized.

## 🧐 Motivation and Background

* Whitespace-only output paths should behave like missing output paths instead of being treated as valid paths.
* Centralizing merge behavior avoids duplicated fallback logic.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [x] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added unit and flow test coverage for whitespace-only config and CLI output paths.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
