### PR TITLE
fix(cli): Reject unknown options [v0.0.12]

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:oxfmt": "oxfmt .",
     "format:oxfmt:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit",
-    "diff2prompt": "bun run src/index.ts --exclude=bun.lock --excludeFile=.gitignore"
+    "diff2prompt": "bun run src/index.ts --exclude=bun.lock --exclude-file=.gitignore"
   },
   "dependencies": {},
   "devDependencies": {

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -75,6 +75,8 @@ export function parseArgs(argv: string[]): Partial<Options> {
       if (v) excludes.push(v);
     } else if (a.startsWith("--exclude-file=")) {
       out.excludeFile = a.slice("--exclude-file=".length);
+    } else if (a.startsWith("--")) {
+      throw new Error(`Unknown option: ${a}`);
     }
   }
   if (excludes.length) out.exclude = excludes;

--- a/src/generate-prompt-from-git-diff.unit.test.ts
+++ b/src/generate-prompt-from-git-diff.unit.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import { describe, it, expect, vi } from "vitest";
 
 import {
@@ -87,9 +89,26 @@ describe("parseArgs", () => {
     expect(p.prTemplateFile).toBe(".github/PR.md");
   });
 
-  it("does not expose --include-pr-template because PR templates are included by default", () => {
-    const p = parseArgs(["node", "script", "--include-pr-template"]);
-    expect(p).toEqual({});
+  it("throws for unknown flags", () => {
+    expect(() => parseArgs(["node", "script", "--include-pr-template"])).toThrow(
+      "Unknown option: --include-pr-template",
+    );
+    expect(() => parseArgs(["node", "script", "--excludeFile=.gitignore"])).toThrow(
+      "Unknown option: --excludeFile=.gitignore",
+    );
+  });
+
+  it("package diff2prompt script uses the supported exclude-file flag", () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    const script = pkg.scripts?.diff2prompt ?? "";
+
+    expect(script).toContain("--exclude-file=.gitignore");
+    expect(script).not.toContain("--excludeFile=");
+
+    const parsed = parseArgs(["node", "script", ...script.split(/\s+/).slice(3)]);
+    expect(parsed.excludeFile).toBe(".gitignore");
   });
 });
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Updated CLI argument parsing to throw an error for unknown flags.
* Fixed the package `diff2prompt` script to use the supported `--exclude-file` option.

## 🧐 Motivation and Background

* Prevent silently ignored invalid CLI options.
* Ensure the package script uses the documented kebab-case flag format.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added tests for unknown flags and package script flag compatibility.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
