### PR TITLE
fix(cli): Validate positive integer options [v0.0.12]

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ diff2prompt [--lines=N] [--no-untracked] [--out=PATH] [--max-new-size=BYTES] [--
 ### Flags
 
 - `--lines=N`
-  Preview line count in the console. Defaults to `MAX_CONSOLE_LINES` env or `10`.
+  Preview line count in the console. Must be a positive integer. Defaults to `MAX_CONSOLE_LINES` env or `10`.
 
 - `--no-untracked`
   Do **not** include new/untracked files in the prompt.
@@ -60,10 +60,10 @@ diff2prompt [--lines=N] [--no-untracked] [--out=PATH] [--max-new-size=BYTES] [--
   (falls back to `process.cwd()` if repo root is unknown).
 
 - `--max-new-size=BYTES`
-  Skip new/untracked files larger than this size. Default: `1_000_000` (1MB).
+  Skip new/untracked files larger than this size. Must be a positive integer. Default: `1_000_000` (1MB).
 
 - `--max-buffer=BYTES`
-  Pass-through to `child_process.exec` for large diffs. Default: `50 * 1024 * 1024`.
+  Pass-through to `child_process.exec` for large diffs. Must be a positive integer. Default: `50 * 1024 * 1024`.
 
 - `--template=STRING`
   Inline template string. Placeholders: `{{diff}}`, `{{now}}`, `{{repoRoot}}`.
@@ -132,6 +132,7 @@ You can set persistent defaults via any of the following (first match wins):
 - `prTemplateFile` specifies a custom path to the PR template.
 - Relative paths are resolved against the repo root.
 - `exclude` and `excludeFile` let you filter out noisy untracked files.
+- Numeric config fields (`maxConsoleLines`, `maxNewFileSizeBytes`, and `maxBuffer`) must be positive integers.
 
 ---
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -289,6 +289,18 @@ describe("normalizeUserConfig", () => {
     expect(cfg).toEqual({});
   });
 
+  it("ignores non-positive and non-integer numbers", () => {
+    const cfg = normalizeUserConfig(
+      rec({
+        maxConsoleLines: 0,
+        maxNewFileSizeBytes: -1,
+        maxBuffer: 1.5,
+      }),
+      "C:/repo",
+    );
+    expect(cfg).toEqual({});
+  });
+
   it("normalizes exclude array and excludeFile (relative -> absolute)", () => {
     const cfg = normalizeUserConfig(
       rec({

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { promisify } from "util";
 
 import { DEFAULT_OUTPUT_FILENAME } from "./constants";
 import type { Options } from "./generate-prompt-from-git-diff";
+import { isPositiveInteger } from "./number-options";
 
 const execFile = promisify(cpExecFile);
 
@@ -102,7 +103,7 @@ function pickString(obj: Record<string, unknown>, key: StringKeys<UserConfig>): 
 function pickNumber(obj: Record<string, unknown>, key: NumberKeys<UserConfig>): number | undefined {
   const v = obj[key];
 
-  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+  return typeof v === "number" && isPositiveInteger(v) ? v : undefined;
 }
 
 function pickBoolean(

--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -294,6 +294,49 @@ describe("generate.ts flow", () => {
     expect(parsed.excludeFile).toBe(".d2p=a.txt");
   });
 
+  it("main(): valid numeric flags are applied", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("");
+    gitMap.setStaged("");
+    gitMap.setUntracked(nulList("tiny.txt"));
+    fsState.files.set("/repo/tiny.txt", { size: 10, buf: Buffer.from("0123456789") });
+
+    const { main } = await importSut();
+    process.argv = [
+      "node",
+      "script",
+      "--lines=2",
+      "--max-new-size=5",
+      "--max-buffer=456",
+      "--out=/repo/OUT.txt",
+    ];
+    await main();
+
+    const out = fsState.writes.at(-1)!;
+    expect(out.data).toMatch(/File: tiny\.txt/);
+    expect(out.data).toMatch(/skipped: too large \(10 bytes\)/);
+    const runGitCalls = fsState.execCalls.filter(({ opts }) => opts !== undefined);
+    expect(runGitCalls.every(({ opts }) => opts?.maxBuffer === 456)).toBe(true);
+
+    const logs = logSpy.mock.calls.flat().join("\n");
+    expect(logs).toContain("... (truncated) ...");
+  });
+
+  it.each([
+    ["--lines=abc", "Invalid value for --lines: expected a positive integer"],
+    ["--max-new-size=-1", "Invalid value for --max-new-size: expected a positive integer"],
+    ["--max-buffer=0", "Invalid value for --max-buffer: expected a positive integer"],
+  ])("main(): rejects invalid numeric flag %s", async (flag, message) => {
+    const { main } = await importSut();
+    process.argv = ["node", "script", flag];
+
+    await expect(main()).rejects.toThrow("process.exit(1)");
+
+    const errOut = errSpy.mock.calls.flat().join("\n");
+    expect(errOut).toContain(`Error: ${message}`);
+    expect(fsState.execCalls).toEqual([]);
+  });
+
   it("main(): diff + untracked (text/binary/huge/error), truncated preview, writes file", async () => {
     const diff = "diff --git a/x b/x\n@@\n-1\n+2\n";
     gitMap.setRoot("/repo\n");

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -15,6 +15,7 @@ import {
   PREVIEW_HEADER,
   TRUNCATED_LINE,
 } from "./constants";
+import { parseCliPositiveInteger } from "./number-options";
 import { tooLargeSkipped, binarySkipped, readError } from "./strings";
 
 const execFile = promisify(cpExecFile);
@@ -56,12 +57,17 @@ export function parseArgs(argv: string[]): Partial<Options> {
   const excludes: string[] = [];
 
   for (const a of argv.slice(2)) {
-    if (a.startsWith("--lines=")) out.maxConsoleLines = Number(a.slice("--lines=".length));
+    if (a.startsWith("--lines="))
+      out.maxConsoleLines = parseCliPositiveInteger("--lines", a.slice("--lines=".length));
     else if (a === "--no-untracked") out.includeUntracked = false;
     else if (a.startsWith("--out=")) out.outputPath = a.slice("--out=".length);
     else if (a.startsWith("--max-new-size="))
-      out.maxNewFileSizeBytes = Number(a.slice("--max-new-size=".length));
-    else if (a.startsWith("--max-buffer=")) out.maxBuffer = Number(a.slice("--max-buffer=".length));
+      out.maxNewFileSizeBytes = parseCliPositiveInteger(
+        "--max-new-size",
+        a.slice("--max-new-size=".length),
+      );
+    else if (a.startsWith("--max-buffer="))
+      out.maxBuffer = parseCliPositiveInteger("--max-buffer", a.slice("--max-buffer=".length));
     else if (a.startsWith("--template-file="))
       out.promptTemplateFile = a.slice("--template-file=".length);
     else if (a.startsWith("--template=")) out.promptTemplate = a.slice("--template=".length);
@@ -238,13 +244,12 @@ export async function loadPrTemplateText(repoRoot: string, opt: Options): Promis
 }
 
 export async function main() {
-  const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
-  const fileCfg = await loadUserConfig(repoRoot);
-  const cli = parseArgs(process.argv);
-
-  const merged = mergeOptions(defaultOptions, fileCfg, cli, repoRoot || null, __DIRNAME_SAFE);
-
   try {
+    const cli = parseArgs(process.argv);
+    const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
+    const fileCfg = await loadUserConfig(repoRoot);
+    const merged = mergeOptions(defaultOptions, fileCfg, cli, repoRoot || null, __DIRNAME_SAFE);
+
     // Validate git repo (leave constant in use)
     await runGit(["rev-parse", "--show-toplevel"], merged);
 

--- a/src/generate-prompt-from-git-diff.unit.test.ts
+++ b/src/generate-prompt-from-git-diff.unit.test.ts
@@ -52,6 +52,18 @@ describe("parseArgs", () => {
     expect(p.maxBuffer).toBe(999);
   });
 
+  it("rejects invalid numeric flags", () => {
+    expect(() => parseArgs(["node", "script", "--lines=abc"])).toThrow(
+      "Invalid value for --lines: expected a positive integer",
+    );
+    expect(() => parseArgs(["node", "script", "--max-new-size=-1"])).toThrow(
+      "Invalid value for --max-new-size: expected a positive integer",
+    );
+    expect(() => parseArgs(["node", "script", "--max-buffer=0"])).toThrow(
+      "Invalid value for --max-buffer: expected a positive integer",
+    );
+  });
+
   it("returns empty when no flags", () => {
     const p = parseArgs(["node", "script"]);
     expect(p).toEqual({});

--- a/src/number-options.ts
+++ b/src/number-options.ts
@@ -1,0 +1,12 @@
+export function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+export function parseCliPositiveInteger(flag: string, rawValue: string): number {
+  const value = Number(rawValue);
+  if (!isPositiveInteger(value)) {
+    throw new Error(`Invalid value for ${flag}: expected a positive integer`);
+  }
+
+  return value;
+}


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added validation for numeric CLI flags and config values so they must be positive integers.
* Documented numeric option requirements in the README.

## 🧐 Motivation and Background

* Prevent invalid numeric values such as `0`, negative numbers, decimals, or non-numeric strings from being accepted silently.
* Ensure CLI errors are reported before Git commands run.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [x] Documentation updated

## 💡 Notes / Screenshots

* Added shared number option helpers in `src/number-options.ts`.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
