### PR TITLE
test(ci): Add Node.js 24 to test matrix [v0.0.12]

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        node-version: [18, 20, 22, aqua]
+        node-version: [18, 20, 22, 24, aqua]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added Node.js 24 to the GitHub Actions Node test matrix.
* Expanded CI coverage to validate compatibility with the latest Node.js release.

## 🧐 Motivation and Background

* Ensure the project continues to work correctly on Node.js 24.
* Detect compatibility issues early as new Node.js versions become available.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Test coverage updated
* [x] CI configuration updated

## 💡 Notes / Screenshots

* The Node test workflow now runs against Node.js 18, 20, 22, 24, and the version defined by Aqua.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
