### PR TITLE
fix(cli): Exclude output file from untracked prompt content [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -1023,6 +1023,136 @@ describe("generate.ts flow", () => {
     expect(s).not.toContain("File: node_modules/x.js");
   });
 
+  it("main(): excludes the default output file from untracked files", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("");
+    gitMap.setStaged("");
+    gitMap.setUntracked(nulList("generated-prompt.txt", "notes.txt"));
+
+    fsState.files.set("/repo/notes.txt", { size: 4, buf: Buffer.from("keep") });
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--lines=50"];
+    await main();
+
+    const out = fsState.writes.at(-1)!;
+    expect(out.path.replace(/\\/g, "/")).toBe("/repo/generated-prompt.txt");
+    expect(out.data).toContain("File: notes.txt");
+    expect(out.data).toContain("keep");
+    expect(out.data).not.toContain("File: generated-prompt.txt");
+
+    const untrackedCall = fsState.execCalls.find(
+      ({ file, args }) =>
+        file === "git" &&
+        args[0] === "ls-files" &&
+        args[1] === "-z" &&
+        args[2] === "--others" &&
+        args[3] === "--exclude-standard",
+    );
+    expect(untrackedCall?.args).toContain(":(exclude)generated-prompt.txt");
+  });
+
+  it("collectDiff(): excludes an explicit repo-root output file from untracked files", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("");
+    gitMap.setStaged("");
+    gitMap.setUntracked(nulList("custom.txt", "src/keep.txt"));
+
+    fsState.files.set("/repo/src/keep.txt", { size: 2, buf: Buffer.from("ok") });
+
+    const { collectDiff, defaultOptions } = await importSut();
+    const s = await collectDiff({
+      ...defaultOptions,
+      includeUntracked: true,
+      outputPath: "/repo/custom.txt",
+    });
+
+    expect(s).toContain("File: src/keep.txt");
+    expect(s).toContain("ok");
+    expect(s).not.toContain("File: custom.txt");
+
+    const untrackedCall = fsState.execCalls.find(
+      ({ file, args }) =>
+        file === "git" &&
+        args[0] === "ls-files" &&
+        args[1] === "-z" &&
+        args[2] === "--others" &&
+        args[3] === "--exclude-standard",
+    );
+    expect(untrackedCall?.args).toContain(":(exclude)custom.txt");
+  });
+
+  it("main(): excludes a config outputFile from untracked files", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("");
+    gitMap.setStaged("");
+    gitMap.setUntracked(nulList("from-config.txt", "src/keep.txt"));
+
+    await mockConfig({
+      getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
+      loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
+        outputPath: "/repo/from-config.txt",
+      }),
+    });
+
+    fsState.files.set("/repo/src/keep.txt", { size: 2, buf: Buffer.from("ok") });
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--lines=50"];
+    await main();
+
+    const out = fsState.writes.at(-1)!;
+    expect(out.path).toBe("/repo/from-config.txt");
+    expect(out.data).toContain("File: src/keep.txt");
+    expect(out.data).not.toContain("File: from-config.txt");
+
+    const untrackedCall = fsState.execCalls.find(
+      ({ file, args }) =>
+        file === "git" &&
+        args[0] === "ls-files" &&
+        args[1] === "-z" &&
+        args[2] === "--others" &&
+        args[3] === "--exclude-standard",
+    );
+    expect(untrackedCall?.args).toContain(":(exclude)from-config.txt");
+  });
+
+  it("collectDiff(): does not add a pathspec exclude for output outside repo root", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("");
+    gitMap.setStaged("");
+    gitMap.setUntracked(nulList("keep.txt"));
+
+    fsState.files.set("/repo/keep.txt", { size: 4, buf: Buffer.from("keep") });
+
+    const { collectDiff, defaultOptions } = await importSut();
+    const s = await collectDiff({
+      ...defaultOptions,
+      includeUntracked: true,
+      outputPath: "/tmp/generated-prompt.txt",
+    });
+
+    expect(s).toContain("File: keep.txt");
+    expect(s).toContain("keep");
+
+    const untrackedCall = fsState.execCalls.find(
+      ({ file, args }) =>
+        file === "git" &&
+        args[0] === "ls-files" &&
+        args[1] === "-z" &&
+        args[2] === "--others" &&
+        args[3] === "--exclude-standard",
+    );
+    expect(untrackedCall?.args).toEqual([
+      "ls-files",
+      "-z",
+      "--others",
+      "--exclude-standard",
+      "--",
+      ".",
+    ]);
+  });
+
   it("main(): --exclude and --exclude-file together (integration)", async () => {
     gitMap.setRoot("/repo\n");
     gitMap.setUnstaged("DIFF\n");

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -1,6 +1,6 @@
 import { execFile as cpExecFile } from "child_process";
 import { readFile, writeFile, stat } from "fs/promises";
-import { join } from "path";
+import { isAbsolute, join, relative, resolve } from "path";
 import { promisify } from "util";
 
 import { getRepoRootSafe, loadUserConfig, mergeOptions } from "./config";
@@ -135,8 +135,23 @@ function toGitSlash(p: string): string {
   return p.replace(/\\/g, "/");
 }
 
+function outputPathToUntrackedExclude(repoRoot: string, outputPath: string): string | null {
+  if (!outputPath.trim()) return null;
+
+  const repoRootAbs = resolve(repoRoot);
+  const outputPathAbs = resolve(outputPath);
+  const rel = relative(repoRootAbs, outputPathAbs);
+  if (!rel || rel.startsWith("..") || isAbsolute(rel)) return null;
+
+  return toGitSlash(rel);
+}
+
 /** Build git pathspec array: [".", ":(exclude)foo", ":(exclude)bar"] */
-async function buildPathspec(repoRoot: string, opt: Options): Promise<string[]> {
+async function buildPathspec(
+  repoRoot: string,
+  opt: Options,
+  extraExcludes: string[] = [],
+): Promise<string[]> {
   const patterns = new Set<string>();
   for (const p of opt.exclude ?? []) patterns.add(p);
   if (opt.excludeFile) {
@@ -145,6 +160,7 @@ async function buildPathspec(repoRoot: string, opt: Options): Promise<string[]> 
       : join(repoRoot, opt.excludeFile);
     for (const line of await readLinesIfExists(abs)) patterns.add(line);
   }
+  for (const p of extraExcludes) patterns.add(p);
   if (patterns.size === 0) return ["."];
 
   return ["."].concat([...patterns].map((p) => `:(exclude)${toGitSlash(p)}`));
@@ -160,7 +176,8 @@ async function buildDiffArgs(repoRoot: string, opt: Options): Promise<string[][]
 }
 
 async function buildUntrackedArgs(repoRoot: string, opt: Options): Promise<string[]> {
-  const ps = await buildPathspec(repoRoot, opt);
+  const outputExclude = outputPathToUntrackedExclude(repoRoot, opt.outputPath);
+  const ps = await buildPathspec(repoRoot, opt, outputExclude ? [outputExclude] : []);
 
   return ["ls-files", "-z", "--others", "--exclude-standard", "--", ...ps];
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Excluded the configured output file from collected untracked files.
* Added test coverage for default, repo-root, and outside-repo output paths.

## 🧐 Motivation and Background

* Prevents `generated-prompt.txt` or a custom output file from being included in the generated prompt when it is untracked.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Not applicable

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
