### PR TITLE
fix(template): Require explicit template files to be readable [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -793,6 +793,43 @@ describe("generate.ts flow", () => {
     }
   });
 
+  it("main(): exits(1) when explicit --template-file is missing", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF-MISSING-TEMPLATE\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--template-file=missing.md", "--out=/repo/OUT.txt"];
+
+    await expect(main()).rejects.toThrow("process.exit(1)");
+
+    const errOut = errSpy.mock.calls.flat().join("\n");
+    expect(errOut).toContain("missing.md");
+    expect(fsState.writes).toEqual([]);
+  });
+
+  it("main(): exits(1) when explicit --template-file is blank", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF-BLANK-TEMPLATE\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    fsState.files.set("/repo/empty.md", {
+      size: 4,
+      buf: Buffer.from(" \n\t ", "utf8"),
+    });
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--template-file=empty.md", "--out=/repo/OUT.txt"];
+
+    await expect(main()).rejects.toThrow("process.exit(1)");
+
+    const errOut = errSpy.mock.calls.flat().join("\n");
+    expect(errOut).toContain("empty.md");
+    expect(fsState.writes).toEqual([]);
+  });
+
   it("main(): template precedence CLI inline > file > preset > default", async () => {
     gitMap.setRoot("/repo\n");
     gitMap.setUnstaged("XYZ\n");
@@ -826,6 +863,39 @@ describe("generate.ts flow", () => {
     expect(out.data).toContain("INLINE-TPL XYZ /repo");
     expect(out.data).not.toContain("FILE-TPL");
     expect(out.data).not.toContain("Please generate **all** of the following");
+  });
+
+  it("main(): inline --template wins over a broken config promptTemplateFile", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("INLINE-DIFF\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    await mockConfig({
+      getRepoRootSafe: vi.fn<() => Promise<string>>().mockResolvedValue("/repo"),
+      loadUserConfig: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
+        promptTemplateFile: "/repo/broken-template.md",
+      }),
+    });
+
+    const { main } = await importSut();
+    const fsmod = await import("fs/promises");
+    const readFileMock = fsmod.readFile as unknown as ReturnType<typeof vi.fn>;
+    readFileMock.mockClear();
+
+    process.argv = [
+      "node",
+      "script",
+      "--template=INLINE-TPL {{diff}} {{repoRoot}}",
+      "--out=/repo/O.txt",
+    ];
+    await main();
+
+    const out = fsState.writes.at(-1)!;
+    expect(out.data).toContain("INLINE-TPL INLINE-DIFF /repo");
+
+    const readPaths = readFileMock.mock.calls.map((call) => String(call[0]).replace(/\\/g, "/"));
+    expect(readPaths).not.toContain("/repo/broken-template.md");
   });
 
   it("main(): falls back to preset when no file/inline provided", async () => {
@@ -916,6 +986,58 @@ describe("generate.ts flow", () => {
     expect(out.data).toContain("- item");
   });
 
+  it("main(): exits(1) when explicit --pr-template-file is missing", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF-MISSING-PR-TEMPLATE\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--out=/repo/OUT.txt", "--pr-template-file=missing.md"];
+
+    await expect(main()).rejects.toThrow("process.exit(1)");
+
+    const errOut = errSpy.mock.calls.flat().join("\n");
+    expect(errOut).toContain("missing.md");
+    expect(fsState.writes).toEqual([]);
+  });
+
+  it("main(): exits(1) when explicit --pr-template-file is blank", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF-BLANK-PR-TEMPLATE\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    fsState.files.set("/repo/empty.md", {
+      size: 4,
+      buf: Buffer.from(" \n\t ", "utf8"),
+    });
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--out=/repo/OUT.txt", "--pr-template-file=empty.md"];
+
+    await expect(main()).rejects.toThrow("process.exit(1)");
+
+    const errOut = errSpy.mock.calls.flat().join("\n");
+    expect(errOut).toContain("empty.md");
+    expect(fsState.writes).toEqual([]);
+  });
+
+  it("main(): succeeds when auto-discovered PR template candidates are missing", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("DIFF-NO-AUTO-PR\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--out=/repo/OUT.txt", "--lines=50"];
+    await main();
+
+    const out = fsState.writes.at(-1)!;
+    expect(out.path).toBe("/repo/OUT.txt");
+    expect(out.data).toContain("DIFF-NO-AUTO-PR");
+  });
+
   it("main(): --no-pr-template disables embedding even if template exists", async () => {
     gitMap.setRoot("/repo\n");
     gitMap.setUnstaged("F\n");
@@ -944,6 +1066,34 @@ describe("generate.ts flow", () => {
     // Since the default preset may output the section itself but leave its contents empty,
     // strongly assert that the content is absent
     expect(out.data).not.toMatch(/### Pull Request Template[\s\S]*PR CONTENT/);
+  });
+
+  it("main(): --no-pr-template does not read a missing --pr-template-file", async () => {
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged("F-MISSING-PR-SKIPPED\n");
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    const fsmod = await import("fs/promises");
+    const readFileMock = fsmod.readFile as unknown as ReturnType<typeof vi.fn>;
+    readFileMock.mockClear();
+
+    process.argv = [
+      "node",
+      "script",
+      "--out=/repo/OUT.txt",
+      "--no-pr-template",
+      "--pr-template-file=missing.md",
+      "--lines=50",
+    ];
+    await main();
+
+    const out = fsState.writes.at(-1)!;
+    expect(out.data).toContain("F-MISSING-PR-SKIPPED");
+
+    const readPaths = readFileMock.mock.calls.map((call) => String(call[0]).replace(/\\/g, "/"));
+    expect(readPaths).not.toContain("/repo/missing.md");
   });
 
   it("main(): includePrTemplate false in config disables default PR template embedding", async () => {

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -113,6 +113,22 @@ export async function readTextFileIfExists(path: string): Promise<string | null>
   }
 }
 
+async function readRequiredTextFile(path: string, label: string): Promise<string> {
+  let txt: string;
+  try {
+    txt = String(await readFile(path, "utf8"));
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to read ${label} file: ${path}: ${msg}`);
+  }
+
+  if (!txt.trim()) {
+    throw new Error(`${label} file is empty: ${path}`);
+  }
+
+  return txt;
+}
+
 /** Read lines from a file, trim, drop comments (# ...) and blanks. */
 async function readLinesIfExists(path: string): Promise<string[]> {
   const txt = await readTextFileIfExists(path);
@@ -241,8 +257,8 @@ export async function loadPrTemplateText(repoRoot: string, opt: Options): Promis
   // 1) Explicit path if provided
   if (opt.prTemplateFile) {
     const p = resolveRepoPath(repoRoot, opt.prTemplateFile);
-    const txt = await readTextFileIfExists(p);
-    if (txt && txt.trim()) return txt;
+
+    return await readRequiredTextFile(p, "PR template");
   }
   // 2) Common defaults (first match wins)
   const candidates = [
@@ -281,8 +297,7 @@ export async function main() {
     } else if (merged.promptTemplateFile) {
       // 2) Template file
       const templatePath = resolveRepoPath(repoRoot, merged.promptTemplateFile);
-      const txt = await readTextFileIfExists(templatePath);
-      templateText = txt?.trim();
+      templateText = (await readRequiredTextFile(templatePath, "prompt template")).trim();
     }
 
     // 3) Preset or 4) Default


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added stricter handling for explicit prompt and PR template files.
* Explicit template paths now fail fast when missing or blank.
* Preserved fallback behavior for auto-discovered PR templates.

## 🧐 Motivation and Background

* Explicitly configured template files should not silently fall back when they are missing or empty.
* This prevents accidentally generating prompts without the intended template content.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* `--no-pr-template` still skips reading PR template files, even if a missing path is provided.
* Inline `--template` still takes precedence over configured template files.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
