### PR TITLE
fix(config): Report explicit config load errors [v0.0.12]

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -101,6 +101,10 @@ function putFile(path: string, json: unknown) {
   mockFiles.set(norm(path), JSON.stringify(json));
 }
 
+function putRawFile(path: string, data: string) {
+  mockFiles.set(norm(path), data);
+}
+
 function rec(v: unknown): Record<string, unknown> {
   return v as Record<string, unknown>;
 }
@@ -144,6 +148,19 @@ describe("config loader & merge", () => {
 
     const cfg = await loadUserConfig("C:/repo");
     expect(cfg.outputPath?.endsWith("env.json.txt")).toBe(true);
+  });
+
+  it("loadUserConfig: rejects when env config path does not exist", async () => {
+    process.env.DIFF2PROMPT_CONFIG = "C:/custom/missing.json";
+
+    await expect(loadUserConfig("C:/repo")).rejects.toThrow("C:/custom/missing.json");
+  });
+
+  it("loadUserConfig: rejects when env config contains invalid JSON", async () => {
+    process.env.DIFF2PROMPT_CONFIG = "C:/custom/broken.json";
+    putRawFile("C:/custom/broken.json", "{ not json");
+
+    await expect(loadUserConfig("C:/repo")).rejects.toThrow("C:/custom/broken.json");
   });
 
   it("loadUserConfig: falls through to diff2prompt.config.json, then .diff2promptrc, then package.json", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,13 +81,49 @@ export async function getRepoRootSafe(): Promise<string | null> {
 }
 
 export async function readJsonIfExists(path: string): Promise<unknown | null> {
+  let buf: string;
   try {
-    const buf = await readFile(path, "utf8");
-
-    return JSON.parse(buf) as unknown;
-  } catch {
-    return null;
+    buf = await readFile(path, "utf8");
+  } catch (err) {
+    if (isFileNotFoundError(err)) return null;
+    throw configReadError(path, err);
   }
+
+  return parseJsonConfig(path, buf);
+}
+
+export async function readJsonRequired(path: string): Promise<unknown> {
+  let buf: string;
+  try {
+    buf = await readFile(path, "utf8");
+  } catch (err) {
+    throw configReadError(path, err);
+  }
+
+  return parseJsonConfig(path, buf);
+}
+
+function parseJsonConfig(path: string, buf: string): unknown {
+  try {
+    return JSON.parse(buf) as unknown;
+  } catch (err) {
+    throw new Error(`Failed to parse config file at ${path}: ${errorMessage(err)}`);
+  }
+}
+
+function isFileNotFoundError(err: unknown): boolean {
+  return (
+    (isRecord(err) && err["code"] === "ENOENT") ||
+    (err instanceof Error && err.message.startsWith("ENOENT"))
+  );
+}
+
+function configReadError(path: string, err: unknown): Error {
+  return new Error(`Failed to read config file at ${path}: ${errorMessage(err)}`);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -192,8 +228,9 @@ export function normalizeUserConfig(cfgRaw: unknown, baseDir: string): Partial<O
 export async function loadUserConfig(baseDir: string): Promise<Partial<Options>> {
   // 1) Explicit path via environment variable
   if (process.env.DIFF2PROMPT_CONFIG) {
-    const cfg = await readJsonIfExists(process.env.DIFF2PROMPT_CONFIG);
-    if (cfg) return normalizeUserConfig(cfg, baseDir);
+    const cfg = await readJsonRequired(process.env.DIFF2PROMPT_CONFIG);
+
+    return normalizeUserConfig(cfg, baseDir);
   }
 
   // 2) Default config files


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added strict loading for `DIFF2PROMPT_CONFIG`.
* Missing or invalid explicit config files now throw clear errors.
* Kept optional default config discovery behavior unchanged.

## 🧐 Motivation and Background

* Explicit config paths should fail fast instead of being silently ignored.
* Clear errors make configuration issues easier to diagnose.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Error messages include the config file path.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
