### PR TITLE
fix(cli): Validate MAX_CONSOLE_LINES [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -337,6 +337,75 @@ describe("generate.ts flow", () => {
     expect(fsState.execCalls).toEqual([]);
   });
 
+  it("main(): uses the default preview line count when MAX_CONSOLE_LINES is unset", async () => {
+    delete process.env.MAX_CONSOLE_LINES;
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged(Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join("\n"));
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--out=/repo/OUT.txt", "--template={{diff}}"];
+    await main();
+
+    const logs = logSpy.mock.calls.flat().join("\n");
+    expect(logs).toContain("line-10");
+    expect(logs).not.toContain("line-11");
+    expect(logs).toContain("... (truncated) ...");
+  });
+
+  it("main(): uses MAX_CONSOLE_LINES when it is a positive integer", async () => {
+    process.env.MAX_CONSOLE_LINES = "20";
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged(Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join("\n"));
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--out=/repo/OUT.txt", "--template={{diff}}"];
+    await main();
+
+    const logs = logSpy.mock.calls.flat().join("\n");
+    expect(logs).toContain("line-12");
+    expect(logs).not.toContain("... (truncated) ...");
+  });
+
+  it.each(["-1", "0", "abc", "", "1.5"])(
+    "main(): rejects invalid MAX_CONSOLE_LINES=%j",
+    async (value) => {
+      process.env.MAX_CONSOLE_LINES = value;
+
+      const { main, parseArgs } = await importSut();
+      expect(parseArgs(["node", "script", "--lines=5"]).maxConsoleLines).toBe(5);
+      process.argv = ["node", "script", "--lines=5", "--out=/repo/OUT.txt"];
+
+      await expect(main()).rejects.toThrow("process.exit(1)");
+
+      const errOut = errSpy.mock.calls.flat().join("\n");
+      expect(errOut).toContain(
+        "Error: Invalid value for MAX_CONSOLE_LINES: expected a positive integer",
+      );
+      expect(fsState.execCalls).toEqual([]);
+    },
+  );
+
+  it("main(): lets --lines override a valid MAX_CONSOLE_LINES value", async () => {
+    process.env.MAX_CONSOLE_LINES = "20";
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged(Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join("\n"));
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--lines=5", "--out=/repo/OUT.txt", "--template={{diff}}"];
+    await main();
+
+    const logs = logSpy.mock.calls.flat().join("\n");
+    expect(logs).toContain("line-5");
+    expect(logs).not.toContain("line-6");
+    expect(logs).toContain("... (truncated) ...");
+  });
+
   it("main(): diff + untracked (text/binary/huge/error), truncated preview, writes file", async () => {
     const diff = "diff --git a/x b/x\n@@\n-1\n+2\n";
     gitMap.setRoot("/repo\n");

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -15,7 +15,7 @@ import {
   PREVIEW_HEADER,
   TRUNCATED_LINE,
 } from "./constants";
-import { parseCliPositiveInteger } from "./number-options";
+import { parseCliPositiveInteger, parseEnvPositiveInteger } from "./number-options";
 import { tooLargeSkipped, binarySkipped, readError, symlinkSkipped } from "./strings";
 
 const execFile = promisify(cpExecFile);
@@ -44,7 +44,7 @@ export interface Options {
 }
 
 export const defaultOptions: Options = {
-  maxConsoleLines: Number(process.env.MAX_CONSOLE_LINES) || MAX_CONSOLE_LINES_DEFAULT,
+  maxConsoleLines: MAX_CONSOLE_LINES_DEFAULT,
   outputPath: "", // temporary, set in main()
   includeUntracked: true,
   maxNewFileSizeBytes: MAX_NEWFILE_SIZE_BYTES,
@@ -283,9 +283,17 @@ export async function loadPrTemplateText(repoRoot: string, opt: Options): Promis
 export async function main() {
   try {
     const cli = parseArgs(process.argv);
+    const defaults = {
+      ...defaultOptions,
+      maxConsoleLines: parseEnvPositiveInteger(
+        "MAX_CONSOLE_LINES",
+        process.env.MAX_CONSOLE_LINES,
+        MAX_CONSOLE_LINES_DEFAULT,
+      ),
+    };
     const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
     const fileCfg = await loadUserConfig(repoRoot);
-    const merged = mergeOptions(defaultOptions, fileCfg, cli, repoRoot || null, __DIRNAME_SAFE);
+    const merged = mergeOptions(defaults, fileCfg, cli, repoRoot || null, __DIRNAME_SAFE);
 
     // Validate git repo (leave constant in use)
     await runGit(["rev-parse", "--show-toplevel"], merged);

--- a/src/number-options.ts
+++ b/src/number-options.ts
@@ -10,3 +10,13 @@ export function parseCliPositiveInteger(flag: string, rawValue: string): number 
 
   return value;
 }
+
+export function parseEnvPositiveInteger(
+  envName: string,
+  rawValue: string | undefined,
+  defaultValue: number,
+): number {
+  if (rawValue === undefined) return defaultValue;
+
+  return parseCliPositiveInteger(envName, rawValue);
+}


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added validation for `MAX_CONSOLE_LINES`.
* Invalid environment values now fail before Git commands run.
* Preserved the default preview line count and `--lines` override behavior.

## 🧐 Motivation and Background

* Invalid environment values could previously fall back silently.
* Explicit validation makes preview behavior predictable and easier to debug.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* `MAX_CONSOLE_LINES` must be a positive integer.
* `--lines` still takes precedence over a valid environment value.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
