### PR TITLE
fix(cli): Let --lines override invalid env value [v0.0.12]

### DIFF
--- a/src/generate-prompt-from-git-diff.flow.test.ts
+++ b/src/generate-prompt-from-git-diff.flow.test.ts
@@ -371,13 +371,12 @@ describe("generate.ts flow", () => {
   });
 
   it.each(["-1", "0", "abc", "", "1.5"])(
-    "main(): rejects invalid MAX_CONSOLE_LINES=%j",
+    "main(): rejects invalid MAX_CONSOLE_LINES=%j when --lines is omitted",
     async (value) => {
       process.env.MAX_CONSOLE_LINES = value;
 
-      const { main, parseArgs } = await importSut();
-      expect(parseArgs(["node", "script", "--lines=5"]).maxConsoleLines).toBe(5);
-      process.argv = ["node", "script", "--lines=5", "--out=/repo/OUT.txt"];
+      const { main } = await importSut();
+      process.argv = ["node", "script", "--out=/repo/OUT.txt"];
 
       await expect(main()).rejects.toThrow("process.exit(1)");
 
@@ -388,6 +387,23 @@ describe("generate.ts flow", () => {
       expect(fsState.execCalls).toEqual([]);
     },
   );
+
+  it("main(): lets --lines override an invalid MAX_CONSOLE_LINES value", async () => {
+    process.env.MAX_CONSOLE_LINES = "abc";
+    gitMap.setRoot("/repo\n");
+    gitMap.setUnstaged(Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join("\n"));
+    gitMap.setStaged("");
+    gitMap.setUntracked("");
+
+    const { main } = await importSut();
+    process.argv = ["node", "script", "--lines=5", "--out=/repo/OUT.txt", "--template={{diff}}"];
+    await main();
+
+    const logs = logSpy.mock.calls.flat().join("\n");
+    expect(logs).toContain("line-5");
+    expect(logs).not.toContain("line-6");
+    expect(logs).toContain("... (truncated) ...");
+  });
 
   it("main(): lets --lines override a valid MAX_CONSOLE_LINES value", async () => {
     process.env.MAX_CONSOLE_LINES = "20";

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -285,11 +285,13 @@ export async function main() {
     const cli = parseArgs(process.argv);
     const defaults = {
       ...defaultOptions,
-      maxConsoleLines: parseEnvPositiveInteger(
-        "MAX_CONSOLE_LINES",
-        process.env.MAX_CONSOLE_LINES,
-        MAX_CONSOLE_LINES_DEFAULT,
-      ),
+      maxConsoleLines:
+        cli.maxConsoleLines ??
+        parseEnvPositiveInteger(
+          "MAX_CONSOLE_LINES",
+          process.env.MAX_CONSOLE_LINES,
+          MAX_CONSOLE_LINES_DEFAULT,
+        ),
     };
     const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
     const fileCfg = await loadUserConfig(repoRoot);


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Fixed CLI option precedence so `--lines` overrides `MAX_CONSOLE_LINES`, even when the environment value is invalid.

## 🧐 Motivation and Background

* CLI arguments should take priority over environment defaults.
* Previously, an invalid `MAX_CONSOLE_LINES` value could still cause `main()` to fail even when `--lines` was provided.

## ✅ Changes

* [ ] Feature added
* [x] Bug fixed
* [ ] Refactored
* [ ] Documentation updated

## 💡 Notes / Screenshots

* Added test coverage for invalid `MAX_CONSOLE_LINES` when `--lines` is omitted.
* Added test coverage confirming `--lines` overrides an invalid environment value.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
