### PR TITLE
test(smoke): Disable GPG signing for test commit [v0.0.12]

### DIFF
--- a/scripts/package-smoke-test.ts
+++ b/scripts/package-smoke-test.ts
@@ -55,7 +55,7 @@ async function verifyBuiltCli(): Promise<void> {
     const trackedPath = join(tempRoot, "tracked.txt");
     await writeFile(trackedPath, "before\n", "utf8");
     await run("git", ["add", "tracked.txt"], tempRoot);
-    await run("git", ["commit", "-m", "Initial commit"], tempRoot);
+    await run("git", ["-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"], tempRoot);
 
     await writeFile(trackedPath, "after\n", "utf8");
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Disabled GPG signing for the smoke test’s temporary Git commit.

## 🧐 Motivation and Background

* Prevents package smoke tests from failing in environments where Git commit signing is enabled but signing keys are unavailable.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Test reliability improved

## 💡 Notes / Screenshots

* Not applicable

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Manual verification completed
