### PR TITLE
feat: add Git-native ignore file support [v0.0.13]

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ diff2prompt [--lines=N] [--no-untracked] [--out=PATH] [--max-new-size=BYTES] [--
 - `--exclude-file=PATH`
   Load exclude patterns (one per line, `#` for comments). Relative paths are resolved against the repo root.
 
+- `--gitignore-file=PATH`
+  Use an additional Git ignore-format file for tracked and untracked files. Git interprets
+  root anchoring, negation, ordering, escaping, and directory-only rules. Relative paths are
+  resolved against the repo root.
+
 - `--no-pr-template`
   Do **not** search for or embed the repository's `pull_request_template.md`.
 
@@ -120,6 +125,7 @@ You can set persistent defaults via any of the following (first match wins):
   "templatePreset": "minimal",
   "exclude": ["dist", "node_modules"],
   "excludeFile": ".gitignore",
+  "gitignoreFile": ".gitignore",
   "includePrTemplate": true,
   "prTemplateFile": ".github/pull_request_template.md"
 }
@@ -131,7 +137,9 @@ You can set persistent defaults via any of the following (first match wins):
   It defaults to `true`; set it to `false` to disable PR template embedding.
 - `prTemplateFile` specifies a custom path to the PR template.
 - Relative paths are resolved against the repo root.
-- `exclude` and `excludeFile` let you filter out noisy untracked files.
+- `exclude`, `excludeFile`, and `gitignoreFile` are combined as exclusions. Negation and ordering
+  inside `gitignoreFile` retain Git's ignore semantics. Unlike the other two fields,
+  `gitignoreFile` applies to tracked changes as well as untracked files.
 - Numeric config fields (`maxConsoleLines`, `maxNewFileSizeBytes`, and `maxBuffer`) must be positive integers.
 
 ---
@@ -153,6 +161,9 @@ diff2prompt --exclude="build dir"
 
 # Exclude from a file
 diff2prompt --exclude-file=.gitignore
+
+# Let Git interpret a Git ignore-format file
+diff2prompt --gitignore-file=.gitignore
 
 # Disable automatic pull request template embedding
 diff2prompt --no-pr-template

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -340,6 +340,12 @@ describe("normalizeUserConfig", () => {
     expect(cfg.excludeFile?.replace(/\\/g, "/")).toBe("C:/abs/ex.txt");
   });
 
+  it("normalizes gitignoreFile relative to the config base directory", () => {
+    const cfg = normalizeUserConfig({ gitignoreFile: ".gitignore" }, "C:/repo");
+
+    expect(cfg.gitignoreFile?.replace(/\\/g, "/")).toBe("C:/repo/.gitignore");
+  });
+
   it("loadUserConfig picks exclude fields from files", async () => {
     putFile("C:/repo/diff2prompt.config.json", {
       exclude: ["dist", "*.snap"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,8 @@ export type UserConfig = Partial<{
   exclude?: string[];
   /** File path that lists excludes (one per line) */
   excludeFile?: string;
+  /** Git ignore-format file interpreted by Git */
+  gitignoreFile?: string;
 }>;
 
 // Extract keys whose value types are assignable to V (e.g., string/number/boolean).
@@ -177,6 +179,7 @@ export function normalizeUserConfig(cfgRaw: unknown, baseDir: string): Partial<O
   const outputFile = pickString(cfgRaw, "outputFile");
   const exclude = pickStringArray(cfgRaw, "exclude");
   const excludeFile = pickString(cfgRaw, "excludeFile");
+  const gitignoreFile = pickString(cfgRaw, "gitignoreFile");
 
   let resolvedOutputPath: string | undefined;
 
@@ -219,6 +222,11 @@ export function normalizeUserConfig(cfgRaw: unknown, baseDir: string): Partial<O
   if (exclude && exclude.length) out.exclude = exclude;
   if (excludeFile && excludeFile.trim()) {
     out.excludeFile = isAbsolutePath(excludeFile) ? excludeFile : join(baseDir, excludeFile);
+  }
+  if (gitignoreFile && gitignoreFile.trim()) {
+    out.gitignoreFile = isAbsolutePath(gitignoreFile)
+      ? gitignoreFile
+      : join(baseDir, gitignoreFile);
   }
 
   return out;

--- a/src/generate-prompt-from-git-diff.ts
+++ b/src/generate-prompt-from-git-diff.ts
@@ -41,6 +41,8 @@ export interface Options {
   exclude?: string[];
   /** A file that lists excludes (one per line). Absolute or relative to repo root. */
   excludeFile?: string;
+  /** A Git ignore-format file interpreted by Git itself. Absolute or relative to repo root. */
+  gitignoreFile?: string;
 }
 
 export const defaultOptions: Options = {
@@ -81,6 +83,8 @@ export function parseArgs(argv: string[]): Partial<Options> {
       if (v) excludes.push(v);
     } else if (a.startsWith("--exclude-file=")) {
       out.excludeFile = a.slice("--exclude-file=".length);
+    } else if (a.startsWith("--gitignore-file=")) {
+      out.gitignoreFile = a.slice("--gitignore-file=".length);
     } else if (a.startsWith("--")) {
       throw new Error(`Unknown option: ${a}`);
     }
@@ -151,6 +155,17 @@ function toGitSlash(p: string): string {
   return p.replace(/\\/g, "/");
 }
 
+function resolveGitignoreFile(repoRoot: string, path: string): string {
+  return toGitSlash(isAbsolutePathLike(path) ? path : join(repoRoot, path));
+}
+
+function parseNulList(stdout: string): string[] {
+  const paths = stdout.split("\0");
+  if (paths.at(-1) === "") paths.pop();
+
+  return paths.map(toGitSlash);
+}
+
 function outputPathToUntrackedExclude(repoRoot: string, outputPath: string): string | null {
   if (!outputPath.trim()) return null;
 
@@ -183,7 +198,32 @@ async function buildPathspec(
 }
 
 async function buildDiffArgs(repoRoot: string, opt: Options): Promise<string[][]> {
-  const ps = await buildPathspec(repoRoot, opt);
+  let ignoredPaths: string[] = [];
+  if (opt.gitignoreFile) {
+    let hasHead = true;
+    try {
+      await runGit(["rev-parse", "--verify", "HEAD"], opt, repoRoot);
+    } catch {
+      hasHead = false;
+    }
+    const withTreeArgs = hasHead ? ["--with-tree=HEAD"] : [];
+    ignoredPaths = parseNulList(
+      await runGit(
+        [
+          "ls-files",
+          "--cached",
+          "--ignored",
+          ...withTreeArgs,
+          `--exclude-from=${resolveGitignoreFile(repoRoot, opt.gitignoreFile)}`,
+          "-z",
+        ],
+        opt,
+        repoRoot,
+      ),
+    );
+  }
+  const ignoredPathspecs = ignoredPaths.map((path) => `:(exclude,top,literal)${path}`);
+  const ps = [...(await buildPathspec(repoRoot, opt)), ...ignoredPathspecs];
 
   return [
     ["diff", "--", ...ps],
@@ -195,12 +235,16 @@ async function buildUntrackedArgs(repoRoot: string, opt: Options): Promise<strin
   const outputExclude = outputPathToUntrackedExclude(repoRoot, opt.outputPath);
   const ps = await buildPathspec(repoRoot, opt, outputExclude ? [outputExclude] : []);
 
-  return ["ls-files", "-z", "--others", "--exclude-standard", "--", ...ps];
+  const ignoreArgs = opt.gitignoreFile
+    ? [`--exclude-from=${resolveGitignoreFile(repoRoot, opt.gitignoreFile)}`]
+    : [];
+
+  return ["ls-files", "-z", "--others", "--exclude-standard", ...ignoreArgs, "--", ...ps];
 }
 
-export async function collectDiff(opt: Options): Promise<string> {
+export async function collectDiff(opt: Options, repoRootOverride?: string): Promise<string> {
   // Resolve repo root for pathspec resolution and exclude-file
-  const repoRoot = (await getRepoRootSafe()) ?? process.cwd();
+  const repoRoot = repoRootOverride ?? (await getRepoRootSafe()) ?? process.cwd();
 
   const [diffArgs, diffCachedArgs] = await buildDiffArgs(repoRoot, opt);
   const unstaged = await runGit(diffArgs, opt, repoRoot);
@@ -210,8 +254,7 @@ export async function collectDiff(opt: Options): Promise<string> {
   if (opt.includeUntracked) {
     const untrackedArgs = await buildUntrackedArgs(repoRoot, opt);
     const filesStdout = await runGit(untrackedArgs, opt, repoRoot);
-    const files = filesStdout.split("\0");
-    if (files.at(-1) === "") files.pop();
+    const files = parseNulList(filesStdout);
 
     if (files.length > 0) {
       full += NEW_FILES_HEADER;

--- a/src/generate-prompt-from-git-diff.unit.test.ts
+++ b/src/generate-prompt-from-git-diff.unit.test.ts
@@ -82,7 +82,7 @@ describe("parseArgs", () => {
     expect(p.templatePreset).toBe("minimal");
   });
 
-  it("parses multiple --exclude and --exclude-file", () => {
+  it("parses multiple --exclude, --exclude-file, and --gitignore-file", () => {
     const p = parseArgs([
       "node",
       "script",
@@ -90,9 +90,11 @@ describe("parseArgs", () => {
       "--exclude=node_modules/",
       "--exclude=*.lock",
       "--exclude-file=ex.txt",
+      "--gitignore-file=.gitignore",
     ]);
     expect(p.exclude).toEqual(["dist", "node_modules/", "*.lock"]);
     expect(p.excludeFile).toBe("ex.txt");
+    expect(p.gitignoreFile).toBe(".gitignore");
   });
 
   it("parses --no-pr-template and --pr-template-file", () => {
@@ -163,6 +165,18 @@ describe("merge behavior (defaults -> file -> cli)", () => {
     const cli = parseArgs(["node", "script", "--out=C:/tmp/cli.txt"]);
     const merged = mergeOptions(defaultOptions, fileCfg, cli, "C:/repo", "C:/cwd");
     expect(merged.outputPath.replace(/\\/g, "/")).toBe("C:/tmp/cli.txt".replace(/\\/g, "/"));
+  });
+
+  it("CLI gitignoreFile overrides file config", () => {
+    const cli = parseArgs(["node", "script", "--gitignore-file=cli.ignore"]);
+    const merged = mergeOptions(
+      defaultOptions,
+      { gitignoreFile: "C:/repo/config.ignore" },
+      cli,
+      "C:/repo",
+      "C:/cwd",
+    );
+    expect(merged.gitignoreFile).toBe("cli.ignore");
   });
 
   it("parseArgs parses other flags and keeps them intact", () => {

--- a/src/gitignore-file.integration.test.ts
+++ b/src/gitignore-file.integration.test.ts
@@ -1,0 +1,178 @@
+import { execFile as execFileCallback } from "child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { collectDiff, defaultOptions } from "./generate-prompt-from-git-diff";
+
+const execFile = promisify(execFileCallback);
+const repos: string[] = [];
+
+async function git(repo: string, args: string[]): Promise<string> {
+  const { stdout } = await execFile("git", args, { cwd: repo, encoding: "utf8" });
+
+  return stdout;
+}
+
+async function createRepo(): Promise<string> {
+  const repo = await mkdtemp(join(tmpdir(), "diff2prompt-gitignore-"));
+  repos.push(repo);
+  await git(repo, ["init", "-q"]);
+
+  return repo;
+}
+
+async function put(repo: string, path: string, contents = path): Promise<void> {
+  const fullPath = join(repo, path);
+  await mkdir(join(fullPath, ".."), { recursive: true });
+  await writeFile(fullPath, contents, "utf8");
+}
+
+async function commitAll(repo: string): Promise<void> {
+  await git(repo, ["add", "."]);
+  await git(repo, [
+    "-c",
+    "user.name=diff2prompt test",
+    "-c",
+    "user.email=diff2prompt@example.invalid",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "--no-gpg-sign",
+    "--no-verify",
+    "-q",
+    "-m",
+    "base",
+  ]);
+}
+
+function options(ignoreFile = "patterns.ignore") {
+  return {
+    ...defaultOptions,
+    outputPath: "",
+    gitignoreFile: ignoreFile,
+  };
+}
+
+describe("--gitignore-file with real Git", () => {
+  afterEach(async () => {
+    await Promise.all(repos.splice(0).map((repo) => rm(repo, { recursive: true, force: true })));
+  });
+
+  it("preserves root anchoring, negation, escaping, directory rules, and spaces", async () => {
+    const repo = await createRepo();
+    await put(
+      repo,
+      "patterns.ignore",
+      [
+        "/build",
+        "dist/*",
+        "!dist/keep.js",
+        String.raw`\#file`,
+        String.raw`\!file`,
+        "cache/",
+        "space dir/",
+        "/node_modules",
+      ].join("\n"),
+    );
+    for (const path of [
+      "build/root.txt",
+      "packages/example/build/nested.txt",
+      "dist/drop.js",
+      "dist/keep.js",
+      "#file",
+      "!file",
+      "cache/value.txt",
+      "space dir/value.txt",
+      "node_modules/module.js",
+    ]) {
+      await put(repo, path);
+    }
+
+    const diff = await collectDiff(options(), repo);
+
+    expect(diff).toContain("packages/example/build/nested.txt");
+    expect(diff).toContain("dist/keep.js");
+    for (const excluded of [
+      "build/root.txt",
+      "dist/drop.js",
+      "#file",
+      "!file",
+      "cache/value.txt",
+      "space dir/value.txt",
+      "node_modules/module.js",
+    ]) {
+      expect(diff).not.toContain(`File: ${excluded}`);
+    }
+  }, 15_000);
+
+  it("a non-root build pattern excludes build directories at every depth", async () => {
+    const repo = await createRepo();
+    await put(repo, "patterns.ignore", "build\n");
+    await put(repo, "build/root.txt");
+    await put(repo, "packages/example/build/nested.txt");
+    await put(repo, "keep.txt");
+
+    const diff = await collectDiff(options(), repo);
+
+    expect(diff).toContain("File: keep.txt");
+    expect(diff).not.toContain("build/root.txt");
+    expect(diff).not.toContain("packages/example/build/nested.txt");
+  }, 15_000);
+
+  it("applies the same ignore source to unstaged, staged, and untracked files", async () => {
+    const repo = await createRepo();
+    await put(repo, "patterns.ignore", "ignored-*\n");
+    for (const path of [
+      "ignored-unstaged.txt",
+      "ignored-staged.txt",
+      "kept-unstaged.txt",
+      "kept-staged.txt",
+    ]) {
+      await put(repo, path, "base\n");
+    }
+    await commitAll(repo);
+    await put(repo, "ignored-unstaged.txt", "changed\n");
+    await put(repo, "ignored-staged.txt", "changed\n");
+    await put(repo, "kept-unstaged.txt", "changed\n");
+    await put(repo, "kept-staged.txt", "changed\n");
+    await git(repo, ["add", "ignored-staged.txt", "kept-staged.txt"]);
+    await put(repo, "ignored-untracked.txt", "hidden\n");
+    await put(repo, "kept-untracked.txt", "visible\n");
+
+    const diff = await collectDiff(options(), repo);
+
+    expect(diff).toContain("kept-unstaged.txt");
+    expect(diff).toContain("kept-staged.txt");
+    expect(diff).toContain("File: kept-untracked.txt");
+    expect(diff).not.toContain("ignored-unstaged.txt");
+    expect(diff).not.toContain("ignored-staged.txt");
+    expect(diff).not.toContain("ignored-untracked.txt");
+  }, 15_000);
+
+  it("uses --with-tree=HEAD to exclude a path deleted from the index", async () => {
+    const repo = await createRepo();
+    await put(repo, "patterns.ignore", "/gone.txt\n");
+    await put(repo, "gone.txt", "base\n");
+    await put(repo, "keep.txt", "base\n");
+    await commitAll(repo);
+    await git(repo, ["rm", "--cached", "-q", "gone.txt"]);
+    await put(repo, "keep.txt", "changed\n");
+
+    const listed = await git(repo, [
+      "ls-files",
+      "--cached",
+      "--ignored",
+      "--with-tree=HEAD",
+      `--exclude-from=${join(repo, "patterns.ignore").replace(/\\/g, "/")}`,
+      "-z",
+    ]);
+    const diff = await collectDiff(options(), repo);
+
+    expect(listed.split("\0")).toContain("gone.txt");
+    expect(diff).toContain("keep.txt");
+    expect(diff).not.toContain("gone.txt");
+  }, 15_000);
+});


### PR DESCRIPTION
# Pull Request Template

## Overview

- Added `--gitignore-file=<path>` for Git ignore-format files.
- Added the corresponding `gitignoreFile` configuration field.
- Delegated ignore parsing to Git to preserve root anchoring, negation, ordering, escaping, and directory-only semantics.
- Applied the ignore file consistently to unstaged, staged, and untracked files.
- Preserved the existing behavior of `--exclude` and `--exclude-file`.

## Motivation and Background

- `--exclude-file` converts each line into a Git pathspec, but Git ignore syntax and pathspec syntax are not equivalent.
- On Windows, an ignore pattern such as `/node_modules` became `:(exclude)/node_modules`, which Git could interpret as an absolute path outside the repository.
- Handling negation, escaping, pattern ordering, and root-relative patterns correctly in Node.js would duplicate Git’s ignore implementation.
- The new option passes the file to Git through `--exclude-from`, allowing Git itself to interpret the patterns.

## Changes

- [x] Feature added
- [x] Bug fixed
- [ ] Refactored
- [x] Documentation updated

- Added CLI support for `--gitignore-file`.
- Added configuration support for `"gitignoreFile"`.
- For untracked files, added `--exclude-from=<file>` while preserving `--exclude-standard`.
- For tracked files, enumerated ignored paths with:
  - `git ls-files --cached --ignored --with-tree=HEAD --exclude-from=<file> -z`
- Converted enumerated paths into exact repository-root-relative exclusions:
  - `:(exclude,top,literal)<path>`
- Applied the same exclusions to both unstaged and staged diffs.
- Added a fallback for repositories without a `HEAD`.
- Normalized Windows path separators to `/`.
- Updated the README with the new CLI and configuration APIs.

## Notes / Screenshots

- `--exclude`, `--exclude-file`, `--gitignore-file`, and the generated output-file exclusion are combined.
- Negation and ordering inside `--gitignore-file` are interpreted as one Git exclude source.
- A very large number of matched tracked files may still reach the operating system’s command-line length limit because exact exclusion pathspecs are passed as individual arguments.

## Testing

- [x] `bun run lint` passed
- [x] `bun run test` passed
- [x] Manual verification completed

Additional checks:

- [x] `bun run typecheck` passed
- [x] `bun run build` passed
- [x] `bun run test:package` passed
- [x] All 125 tests passed
- [x] Verified root-relative and non-root-relative patterns
- [x] Verified negation and pattern ordering
- [x] Verified escaped `#` and `!`
- [x] Verified directory-only patterns and paths containing spaces
- [x] Verified `/node_modules` on Windows
- [x] Verified unstaged, staged, and untracked exclusions
- [x] Verified paths present in `HEAD` but deleted from the index
- [x] Verified existing `--exclude-file` tests remain passing