### PR TITLE
chore: use gitignore-file in diff2prompt script [v0.0.13]

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format:oxfmt": "oxfmt .",
     "format:oxfmt:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit",
-    "diff2prompt": "bun run src/index.ts --exclude=bun.lock --exclude-file=.gitignore"
+    "diff2prompt": "bun run src/index.ts --exclude=bun.lock --gitignore-file=.gitignore"
   },
   "dependencies": {},
   "devDependencies": {

--- a/src/generate-prompt-from-git-diff.unit.test.ts
+++ b/src/generate-prompt-from-git-diff.unit.test.ts
@@ -112,17 +112,18 @@ describe("parseArgs", () => {
     );
   });
 
-  it("package diff2prompt script uses the supported exclude-file flag", () => {
+  it("package diff2prompt script uses the Git ignore-format file flag", () => {
     const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")) as {
       scripts?: Record<string, string>;
     };
     const script = pkg.scripts?.diff2prompt ?? "";
 
-    expect(script).toContain("--exclude-file=.gitignore");
+    expect(script).toContain("--gitignore-file=.gitignore");
+    expect(script).not.toContain("--exclude-file=.gitignore");
     expect(script).not.toContain("--excludeFile=");
 
     const parsed = parseArgs(["node", "script", ...script.split(/\s+/).slice(3)]);
-    expect(parsed.excludeFile).toBe(".gitignore");
+    expect(parsed.gitignoreFile).toBe(".gitignore");
   });
 });
 


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Updated the `diff2prompt` package script to use `--gitignore-file=.gitignore` instead of `--exclude-file=.gitignore`.
* Updated the unit test to verify that the Git ignore-format file option is parsed as `gitignoreFile`.
* Added an assertion to prevent the previous `--exclude-file=.gitignore` option from being used.

## 🧐 Motivation and Background

* The `.gitignore` file uses Git ignore syntax and should be passed through the dedicated `--gitignore-file` option.
* This ensures that ignore patterns are interpreted using the correct format and keeps the package script aligned with the supported CLI options.

## ✅ Changes

* [ ] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [ ] Documentation updated
* [x] Build or tool configuration updated
* [x] Tests updated

## 💡 Notes / Screenshots

* No screenshots are required because this change only affects the package script configuration and its unit test.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [x] Unit test updated to validate the new CLI option
* [ ] Manual verification completed
