### PR TITLE
feat(config): add JSON Schema for configuration [v0.0.14]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ By default, the tool:
 ```bash
 diff2prompt [--lines=N] [--no-untracked] [--out=PATH] [--max-new-size=BYTES] [--max-buffer=BYTES] \
             [--template=STRING] [--template-file=PATH] [--template-preset=NAME] \
-            [--exclude=GLOB] [--exclude-file=PATH] [--pr-template-file=PATH] [--no-pr-template]
+            [--exclude=GLOB] [--exclude-file=PATH] [--gitignore-file=PATH] \
+            [--pr-template-file=PATH] [--no-pr-template]
 ```
 
 ### Flags
@@ -75,11 +76,13 @@ diff2prompt [--lines=N] [--no-untracked] [--out=PATH] [--max-new-size=BYTES] [--
   Use a built-in preset (currently `default`, `minimal`, `ja`). Falls back to `default` if unknown.
 
 - `--exclude=GLOB`
-  Skip untracked files matching the given pattern. Supports multiple uses.
+  Exclude paths matching the given Git pathspec-style pattern. Supports multiple uses.
   Example: `--exclude=dist --exclude="build dir"`
 
 - `--exclude-file=PATH`
-  Load exclude patterns (one per line, `#` for comments). Relative paths are resolved against the repo root.
+  Load Git pathspec-style exclude patterns (one per line, `#` for comments). This is not
+  a Git ignore-format file; use `--gitignore-file` for `.gitignore` semantics. Relative
+  paths are resolved against the repo root.
 
 - `--gitignore-file=PATH`
   Use an additional Git ignore-format file for tracked and untracked files. Git interprets
@@ -114,6 +117,7 @@ You can set persistent defaults via any of the following (first match wins):
 
 ```json
 {
+  "$schema": "node_modules/diff2prompt/dist/schema.json",
   "outputPath": "generated-prompt.txt",
   "outputFile": "generated-prompt.txt",
   "maxConsoleLines": 15,
@@ -124,22 +128,25 @@ You can set persistent defaults via any of the following (first match wins):
   "promptTemplateFile": ".github/prompt.tpl.md",
   "templatePreset": "minimal",
   "exclude": ["dist", "node_modules"],
-  "excludeFile": ".gitignore",
+  "excludeFile": ".diff2promptignore",
   "gitignoreFile": ".gitignore",
   "includePrTemplate": true,
   "prTemplateFile": ".github/pull_request_template.md"
 }
 ```
 
+- Add `$schema` to enable editor completion and validation for JSON config files.
 - `outputPath` takes precedence over `outputFile` if both are present.
 - `promptTemplate` (inline string) has the highest priority, then `promptTemplateFile`, then `templatePreset`, then built-in default.
 - `includePrTemplate` controls whether diff2prompt searches for and embeds PR template contents.
   It defaults to `true`; set it to `false` to disable PR template embedding.
 - `prTemplateFile` specifies a custom path to the PR template.
 - Relative paths are resolved against the repo root.
-- `exclude`, `excludeFile`, and `gitignoreFile` are combined as exclusions. Negation and ordering
-  inside `gitignoreFile` retain Git's ignore semantics. Unlike the other two fields,
-  `gitignoreFile` applies to tracked changes as well as untracked files.
+- `exclude` and `excludeFile` use Git pathspec-style exclude patterns.
+- `gitignoreFile` uses Git ignore-format rules. Negation and ordering inside `gitignoreFile`
+  retain Git's ignore semantics.
+- `exclude`, `excludeFile`, and `gitignoreFile` are combined as exclusions for tracked changes
+  and untracked files.
 - Numeric config fields (`maxConsoleLines`, `maxNewFileSizeBytes`, and `maxBuffer`) must be positive integers.
 
 ---
@@ -159,8 +166,8 @@ diff2prompt --exclude=dist --exclude=node_modules
 # Exclude with spaces
 diff2prompt --exclude="build dir"
 
-# Exclude from a file
-diff2prompt --exclude-file=.gitignore
+# Exclude from a pathspec-style pattern file
+diff2prompt --exclude-file=.diff2promptignore
 
 # Let Git interpret a Git ignore-format file
 diff2prompt --gitignore-file=.gitignore

--- a/build.ts
+++ b/build.ts
@@ -1,5 +1,7 @@
 import { build } from "esbuild";
 import type { BuildOptions } from "esbuild";
+import { copyFile, mkdir } from "fs/promises";
+import { dirname } from "path";
 
 import pkg from "./package.json";
 
@@ -22,3 +24,7 @@ await build({
     js: "#!/usr/bin/env node",
   },
 });
+
+const schemaOutputPath = "dist/schema.json";
+await mkdir(dirname(schemaOutputPath), { recursive: true });
+await copyFile("schema/diff2prompt.schema.json", schemaOutputPath);

--- a/schema/diff2prompt.schema.json
+++ b/schema/diff2prompt.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/watanabe-1/diff2prompt/main/schema/diff2prompt.schema.json",
+  "title": "diff2prompt configuration",
+  "description": "Configuration for diff2prompt.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for editor completion and validation."
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "Output file path. Relative paths are resolved against the repository root."
+    },
+    "outputFile": {
+      "type": "string",
+      "description": "Legacy alias for outputPath. outputPath takes precedence when both are set."
+    },
+    "maxConsoleLines": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of prompt lines to preview in the console."
+    },
+    "includeUntracked": {
+      "type": "boolean",
+      "description": "Whether to include new and untracked files in the generated prompt."
+    },
+    "maxNewFileSizeBytes": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum size, in bytes, of a new or untracked file to include."
+    },
+    "maxBuffer": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum child_process exec buffer size, in bytes, for Git commands."
+    },
+    "promptTemplate": {
+      "type": "string",
+      "description": "Inline prompt template. Supports placeholders such as {{diff}}, {{now}}, {{repoRoot}}, and {{prTemplate}}."
+    },
+    "promptTemplateFile": {
+      "type": "string",
+      "description": "Path to a prompt template file. Relative paths are resolved against the repository root."
+    },
+    "templatePreset": {
+      "type": "string",
+      "description": "Built-in prompt template preset name. Known presets are default, minimal, and ja.",
+      "examples": ["default", "minimal", "ja"]
+    },
+    "exclude": {
+      "type": "array",
+      "description": "Git pathspec-style exclude patterns.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "excludeFile": {
+      "type": "string",
+      "description": "Path to a file that lists Git pathspec-style exclude patterns, one per line. This is not a Git ignore-format file. Relative paths are resolved against the repository root."
+    },
+    "gitignoreFile": {
+      "type": "string",
+      "description": "Path to a Git ignore-format file interpreted by Git, such as .gitignore. Relative paths are resolved against the repository root."
+    },
+    "includePrTemplate": {
+      "type": "boolean",
+      "description": "Whether to search for and embed pull_request_template.md content."
+    },
+    "prTemplateFile": {
+      "type": "string",
+      "description": "Path to a pull request template file. Relative paths are resolved against the repository root."
+    }
+  }
+}

--- a/scripts/package-smoke-test.ts
+++ b/scripts/package-smoke-test.ts
@@ -35,7 +35,13 @@ async function verifyPackContents(): Promise<void> {
   const stdout = await run("npm", ["pack", "--dry-run", "--json"]);
   const parsed = JSON.parse(stdout) as PackEntry[];
   const files = new Set(parsed.flatMap((entry) => entry.files ?? []).map((file) => file.path));
-  const requiredFiles = ["package.json", "README.md", "LICENSE", "dist/index.js"];
+  const requiredFiles = [
+    "package.json",
+    "README.md",
+    "LICENSE",
+    "dist/index.js",
+    "dist/schema.json",
+  ];
 
   for (const requiredFile of requiredFiles) {
     if (!files.has(requiredFile)) {


### PR DESCRIPTION
# Pull Request Template

## 📝 Overview

* Added a JSON Schema for `diff2prompt` configuration files.
* Included the schema in the distributed npm package as `dist/schema.json`.
* Documented how to enable editor completion and validation using the `$schema` property.
* Clarified the differences between pathspec-style exclusions and Git ignore-format rules.

## 🧐 Motivation and Background

* Configuration files previously had no schema for editor completion or validation.
* Users could confuse `excludeFile` pathspec patterns with `.gitignore` semantics.
* The published package should include the schema so consumers can reference it directly from `node_modules`.

## ✅ Changes

* [x] Feature added
* [ ] Bug fixed
* [ ] Refactored
* [x] Documentation updated

## 💡 Notes / Screenshots

* JSON configuration files can enable editor support with:

  ```json
  {
    "$schema": "node_modules/diff2prompt/dist/schema.json"
  }
  ```

* `exclude` and `excludeFile` use Git pathspec-style patterns.

* `gitignoreFile` uses Git ignore-format rules.

## 🔄 Testing

* [ ] `bun run lint` passed
* [ ] `bun run test` passed
* [ ] Manual verification completed
* [ ] Confirmed `npm pack --dry-run --json` includes `dist/schema.json`
